### PR TITLE
docs: add partial platform playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The support tiers are `native`, `partial`, and `planned`.
 
 See [docs/platforms.md](docs/platforms.md) for the support matrix, platform-specific caveats, and the current claim boundary. The short version is that we do not claim universal agent support, and we do not claim hook parity or compact automation for Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, or Kimi.
 
+For exact post-install steps on each partial platform, see [docs/platform-playbooks.md](docs/platform-playbooks.md).
+
 ## Concrete Stories
 
 The visuals in this repo are about specific interrupted-work situations, not abstract architecture theater.
@@ -83,6 +85,7 @@ Without a checked-in continuity contract, teams repeat themselves. With one, the
 ## See Also
 
 - [Platform support](docs/platforms.md)
+- [Platform playbooks](docs/platform-playbooks.md)
 - [Architecture](docs/architecture.md)
 - [Competitive analysis](docs/competitive-analysis.md)
 - [Planned platform roadmap](docs/launch/platform-roadmap.md)

--- a/docs/platform-playbooks.md
+++ b/docs/platform-playbooks.md
@@ -1,0 +1,174 @@
+# Platform Playbooks
+
+These playbooks explain what to do after `repo-context-hooks install --platform <name>` for each partial platform.
+
+Use them as the operating guide for platforms that do not expose Claude-style lifecycle hooks. The core rule is simple: keep `README.md`, `specs/README.md`, and `AGENTS.md` as the repo contract, then map that contract into the strongest real surface each platform exposes.
+
+Every partial platform has the same claim boundary:
+
+- no native lifecycle hooks
+- no compact automation
+- no Claude-style hook parity
+- no claim that hosted or runtime state is verified unless `doctor` can check it locally
+
+## Replit
+
+Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/2
+
+### What gets installed
+
+- `AGENTS.md`
+- `replit.md`
+
+### What remains manual
+
+- Start or resume the Replit Agent from the repo root.
+- Tell the agent to read `replit.md`, `AGENTS.md`, `README.md`, and `specs/README.md` before making changes.
+- Write durable decisions or next work back into repo docs before ending the session.
+
+### What `doctor` verifies
+
+- `AGENTS.md` exists and points to the repo contract.
+- `replit.md` exists and references `README.md`, `specs/README.md`, and `AGENTS.md`.
+
+### What not to claim
+
+- Do not claim native lifecycle hooks.
+- Do not claim compact automation.
+- Do not claim that Replit interruption or resume behavior is controlled by this package.
+
+## Windsurf
+
+Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/8
+
+### What gets installed
+
+- `AGENTS.md`
+- `.windsurf/rules/repo-context-continuity.md`
+
+### What remains manual
+
+- Keep root `AGENTS.md` as the short repo operating contract.
+- Use `.windsurf/rules/repo-context-continuity.md` as the always-on Cascade rule that points back to the repo contract.
+- Add project-specific Windsurf rules separately if the repo needs them, but do not duplicate the whole contract.
+
+### What `doctor` verifies
+
+- `AGENTS.md` exists and points to the repo contract.
+- `.windsurf/rules/repo-context-continuity.md` exists and references `README.md`, `specs/README.md`, and `AGENTS.md`.
+
+### What not to claim
+
+- Do not claim native lifecycle hooks.
+- Do not claim compact automation.
+- Do not claim that Windsurf rules are equivalent to Claude hooks.
+
+## Lovable
+
+Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/3
+
+### What gets installed
+
+- `AGENTS.md`
+- `.lovable/project-knowledge.md`
+- `.lovable/workspace-knowledge.md`
+
+### What remains manual
+
+- Connect Lovable to the synced GitHub repository.
+- Paste `.lovable/project-knowledge.md` into Lovable Project Knowledge.
+- Paste `.lovable/workspace-knowledge.md` into Lovable Workspace Knowledge if shared rules are useful.
+- Re-paste the hosted knowledge fields whenever the repo-owned exports change.
+
+### What `doctor` verifies
+
+- The local repo-owned export files exist.
+- The export files reference the repo contract.
+
+### What not to claim
+
+- Do not claim native lifecycle hooks.
+- Do not claim compact automation.
+- Do not claim local verification of Lovable's hosted Project Knowledge or Workspace Knowledge state.
+
+## OpenClaw
+
+Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/5
+
+### What gets installed
+
+- `AGENTS.md`
+- `SOUL.md`
+- `USER.md`
+- `TOOLS.md`
+
+### What remains manual
+
+- Point OpenClaw `agents.defaults.workspace` to the repo root, or copy the generated files into the active OpenClaw workspace.
+- Keep secrets and private memory out of public repos.
+- Run OpenClaw setup or doctor after changing workspace configuration.
+
+### What `doctor` verifies
+
+- The generated workspace files exist locally.
+- The workspace files reference `README.md`, `specs/README.md`, `AGENTS.md`, and the repo as the continuity source of truth.
+
+### What not to claim
+
+- Do not claim native lifecycle hooks.
+- Do not claim compact automation.
+- Do not claim that local `doctor` verifies the active OpenClaw workspace path.
+
+## Ollama
+
+Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/4
+
+### What gets installed
+
+- `AGENTS.md`
+- `Modelfile.repo-context`
+
+### What remains manual
+
+- Edit the `FROM` line in `Modelfile.repo-context` if you prefer a different local model.
+- Run `ollama create repo-context-helper -f Modelfile.repo-context`.
+- Use the created model through an agent wrapper that can read repo files, or paste `README.md`, `specs/README.md`, and `AGENTS.md` when using direct `ollama run`.
+
+### What `doctor` verifies
+
+- `Modelfile.repo-context` exists.
+- The Modelfile includes `FROM`, `SYSTEM`, `README.md`, `specs/README.md`, `AGENTS.md`, and the repo continuity instruction.
+
+### What not to claim
+
+- Do not claim native lifecycle hooks.
+- Do not claim compact automation.
+- Do not claim Ollama reads repo files automatically.
+
+Ollama is a model runtime. It does not read repo files automatically. `repo-context-hooks` gives it a repeatable repo-context prompt, but an agent wrapper or user prompt must still provide the actual file contents.
+
+## Kimi
+
+Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/6
+
+### What gets installed
+
+- `AGENTS.md`
+
+### What remains manual
+
+- Run or review Kimi Code CLI `/init` output.
+- Merge any generated Kimi guidance with the repo-owned `AGENTS.md` contract.
+- Keep Kimi-specific rules out of public claims until a stable Kimi rules path is documented.
+
+### What `doctor` verifies
+
+- `AGENTS.md` exists and points to `README.md`, `specs/README.md`, and the repo as the continuity source of truth.
+
+### What not to claim
+
+- Do not claim native lifecycle hooks.
+- Do not claim compact automation.
+- Do not claim generic Kimi API setup.
+
+This support is for Kimi Code CLI project context, not generic Kimi API setup.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -29,6 +29,8 @@ Use the matrix above as the public boundary for support claims:
 - do not describe planned platforms as implemented
 - do not claim native lifecycle hooks or compact automation on partial platforms unless the platform actually exposes them
 
+For step-by-step post-install guidance, use [docs/platform-playbooks.md](platform-playbooks.md).
+
 ## How To Read The Matrix
 
 A platform can still be valuable at `partial` tier. The product promise is not "every agent exposes the same primitives." The promise is that the repo can remain the continuity boundary even when the automation surface changes.

--- a/tests/test_platform_playbooks.py
+++ b/tests/test_platform_playbooks.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_platform_playbooks_doc_exists_and_is_linked() -> None:
+    playbooks = ROOT / "docs" / "platform-playbooks.md"
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    platforms = (ROOT / "docs" / "platforms.md").read_text(encoding="utf-8")
+
+    assert playbooks.exists()
+    assert "docs/platform-playbooks.md" in readme
+    assert "docs/platform-playbooks.md" in platforms
+
+
+def test_platform_playbooks_cover_supported_platforms_and_boundaries() -> None:
+    text = (ROOT / "docs" / "platform-playbooks.md").read_text(encoding="utf-8")
+
+    expected_snippets = [
+        "# Platform Playbooks",
+        "## Replit",
+        "## Windsurf",
+        "## Lovable",
+        "## OpenClaw",
+        "## Ollama",
+        "## Kimi",
+        "What gets installed",
+        "What remains manual",
+        "What not to claim",
+        "no native lifecycle hooks",
+        "no compact automation",
+        "https://github.com/narendranathe/repo-context-hooks/issues/2",
+        "https://github.com/narendranathe/repo-context-hooks/issues/3",
+        "https://github.com/narendranathe/repo-context-hooks/issues/4",
+        "https://github.com/narendranathe/repo-context-hooks/issues/5",
+        "https://github.com/narendranathe/repo-context-hooks/issues/6",
+        "https://github.com/narendranathe/repo-context-hooks/issues/8",
+    ]
+    for snippet in expected_snippets:
+        assert snippet in text, f"missing playbook snippet: {snippet}"
+
+
+def test_platform_playbooks_keep_ollama_and_kimi_claims_narrow() -> None:
+    text = (ROOT / "docs" / "platform-playbooks.md").read_text(encoding="utf-8")
+
+    assert "Ollama is a model runtime" in text
+    assert "does not read repo files automatically" in text
+    assert "Kimi Code CLI" in text
+    assert "not generic Kimi API setup" in text


### PR DESCRIPTION
## Summary
Adds step-by-step playbooks for every current partial platform so developers know what `install`, `doctor`, and manual follow-up mean in practice.

### What changed
- Adds `docs/platform-playbooks.md` covering Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi.
- Links playbooks from README and platform support docs.
- Adds tests that protect the playbook coverage and claim boundaries.

### Why
The support matrix explains tiers, but developers also need post-install operating guidance. This gives each partial platform the same clear shape:
- what gets installed
- what remains manual
- what `doctor` verifies
- what not to claim
- follow-up issue link

### Verification
- `python -m pytest -q --basetemp C:\Users\naren\projects\.tmp\pytest-platform-playbooks-full`
- Result: `83 passed`

### Notes
- Existing untracked local files `UBIQUITOUS_LANGUAGE.md` and `specs/` were left untouched.