### PR TITLE
docs: polish partial platform guidance

### DIFF
--- a/docs/platform-playbooks.md
+++ b/docs/platform-playbooks.md
@@ -37,6 +37,12 @@ Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/2
 - Do not claim compact automation.
 - Do not claim that Replit interruption or resume behavior is controlled by this package.
 
+### Restart checklist
+
+1. Re-open the repo at the project root.
+2. Read `replit.md`, `AGENTS.md`, `README.md`, and `specs/README.md`.
+3. Capture the last completed change and the next step in `specs/README.md` before handing off again.
+
 ## Windsurf
 
 Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/8
@@ -62,6 +68,12 @@ Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/8
 - Do not claim native lifecycle hooks.
 - Do not claim compact automation.
 - Do not claim that Windsurf rules are equivalent to Claude hooks.
+
+### Layering example
+
+- Put repo continuity in `AGENTS.md` and `.windsurf/rules/repo-context-continuity.md`.
+- Put team-wide or personal Cascade preferences in separate Windsurf rules.
+- Keep this repo rule focused on repo-specific continuity only.
 
 ## Lovable
 
@@ -91,6 +103,12 @@ Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/3
 - Do not claim compact automation.
 - Do not claim local verification of Lovable's hosted Project Knowledge or Workspace Knowledge state.
 
+### Resync loop
+
+1. Update `.lovable/project-knowledge.md` or `.lovable/workspace-knowledge.md` in git.
+2. Push the repo changes to the default branch.
+3. Re-paste the updated file into the matching Lovable UI field so the hosted field stays a mirror of the repo-owned export.
+
 ## OpenClaw
 
 Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/5
@@ -118,6 +136,11 @@ Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/5
 - Do not claim native lifecycle hooks.
 - Do not claim compact automation.
 - Do not claim that local `doctor` verifies the active OpenClaw workspace path.
+
+### Safe split
+
+- Keep repo-safe project guidance in `AGENTS.md`, `SOUL.md`, `USER.md`, and `TOOLS.md`.
+- Keep personal workflow notes, secrets, and private memory in a private workspace, not in the public repo files.
 
 ## Ollama
 
@@ -147,6 +170,12 @@ Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/4
 
 Ollama is a model runtime. It does not read repo files automatically. `repo-context-hooks` gives it a repeatable repo-context prompt, but an agent wrapper or user prompt must still provide the actual file contents.
 
+### Safe smoke test
+
+1. Create the model with `ollama create repo-context-helper -f Modelfile.repo-context`.
+2. Start a short prompt without pasting repo files.
+3. Confirm the model asks for `README.md`, `specs/README.md`, and `AGENTS.md` instead of inventing repo state.
+
 ## Kimi
 
 Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/6
@@ -172,3 +201,9 @@ Follow-up issue: https://github.com/narendranathe/repo-context-hooks/issues/6
 - Do not claim generic Kimi API setup.
 
 This support is for Kimi Code CLI project context, not generic Kimi API setup.
+
+### `/init` merge example
+
+1. Run Kimi Code CLI `/init` or review its generated guidance.
+2. Keep the repo-owned `AGENTS.md` contract as the baseline.
+3. Merge any useful project-structure or build notes from `/init` into `AGENTS.md` without replacing the repo contract.

--- a/repo_context_hooks/bundle/templates/lovable-project-knowledge.md
+++ b/repo_context_hooks/bundle/templates/lovable-project-knowledge.md
@@ -4,4 +4,6 @@
 - Use `specs/README.md` as the engineering continuity source for constraints, decisions, failures, and next work.
 - Read `AGENTS.md` before making major structural changes.
 - Keep repo documentation aligned with changes pushed to the default branch so Lovable sync stays trustworthy.
+- After updating this file in git, re-paste it into Lovable Project Knowledge.
+- The hosted field is a mirror of this repo-owned export, not the source of truth.
 - Prefer updating checked-in repo docs over relying on chat-only project memory.

--- a/repo_context_hooks/bundle/templates/lovable-workspace-knowledge.md
+++ b/repo_context_hooks/bundle/templates/lovable-workspace-knowledge.md
@@ -4,4 +4,6 @@
 - Respect `README.md`, `specs/README.md`, and `AGENTS.md` before generating broad changes.
 - Keep instructions concise, specific, and easy to review in git.
 - Use the default branch as the sync baseline for repo-owned continuity files.
+- After updating this file in git, re-paste it into Lovable Workspace Knowledge.
+- Treat this as a repo-owned workspace export whose hosted field is a mirror.
 - Do not imply lifecycle hooks or compact automation that Lovable does not expose.

--- a/repo_context_hooks/bundle/templates/ollama-modelfile
+++ b/repo_context_hooks/bundle/templates/ollama-modelfile
@@ -2,6 +2,9 @@
 #
 # Ollama is a model runtime. This Modelfile gives a local model repo-context
 # instructions, but it does not grant file-system access or lifecycle hooks.
+# Best used through an agent wrapper that can pass real repo file contents.
+# Safe smoke test: run without file contents and verify the model asks for
+# README.md, specs/README.md, and AGENTS.md instead of inventing repo state.
 
 FROM llama3.2
 

--- a/repo_context_hooks/bundle/templates/openclaw-soul.md
+++ b/repo_context_hooks/bundle/templates/openclaw-soul.md
@@ -7,4 +7,5 @@ This is repo-safe OpenClaw persona guidance for this repository.
 - Read `specs/README.md` for engineering decisions, constraints, failures, and next work.
 - Read `AGENTS.md` for the operating contract before making changes.
 - Stay technical, concise, and evidence-driven.
+- Put private workspace preferences in a private workspace file, not this repo file.
 - Do not store secrets, credentials, or private memory in this public repo file.

--- a/repo_context_hooks/bundle/templates/openclaw-tools.md
+++ b/repo_context_hooks/bundle/templates/openclaw-tools.md
@@ -7,4 +7,5 @@ OpenClaw tool notes for this repository.
 - Read `README.md`, `specs/README.md`, and `AGENTS.md` before starting implementation.
 - Prefer checked-in project context over chat-only summaries.
 - Record durable next-step context back into repo docs when a session is interrupted.
+- Keep private workspace tooling preferences in a private workspace file, not this repo file.
 - This file is guidance only; it does not grant or restrict tool access.

--- a/repo_context_hooks/bundle/templates/openclaw-user.md
+++ b/repo_context_hooks/bundle/templates/openclaw-user.md
@@ -6,4 +6,5 @@ This is repo-safe OpenClaw user context for this repository.
 - Start from `README.md`, then `specs/README.md`, then `AGENTS.md`.
 - Assume project intent and contribution guidance live in `README.md`.
 - Assume design decisions, tradeoffs, failures, and next work live in `specs/README.md`.
+- Put per-user private notes in a private workspace file, not this repo file.
 - Keep personal details, secrets, and credentials out of this file.

--- a/repo_context_hooks/bundle/templates/replit.md
+++ b/repo_context_hooks/bundle/templates/replit.md
@@ -17,3 +17,10 @@
 - Prefer small, reviewable changes over broad rewrites.
 - Do not invent lifecycle hooks or automation that Replit does not expose.
 - If the work is interrupted, leave the next session a clearer repo state than the one you inherited.
+
+## Resume Checklist
+
+- Re-open the repo from the project root before starting a fresh Replit Agent session.
+- Read `replit.md`, `AGENTS.md`, `README.md`, and `specs/README.md` in that order.
+- State the last completed change before editing anything new.
+- State the next step you plan to take so the repo handoff stays reviewable.

--- a/repo_context_hooks/bundle/templates/windsurf-rule.md
+++ b/repo_context_hooks/bundle/templates/windsurf-rule.md
@@ -7,5 +7,7 @@ trigger: always_on
 - Read `README.md` for user-facing intent and contribution guidance.
 - Read `specs/README.md` for engineering constraints, decisions, failures, and next work.
 - Read `AGENTS.md` for the repo operating contract.
+- Keep this rule focused on repo-specific continuity only.
+- Keep team-wide or personal Cascade rules in separate Windsurf rule files.
 - Prefer checked-in continuity over auto-generated memory when they conflict.
 - Preserve next-step context back into repo files instead of chat-only state.

--- a/tests/test_platform_polish_contract.py
+++ b/tests/test_platform_polish_contract.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_replit_and_windsurf_templates_include_polish_guidance() -> None:
+    replit = (ROOT / "repo_context_hooks" / "bundle" / "templates" / "replit.md").read_text(
+        encoding="utf-8"
+    )
+    windsurf = (
+        ROOT / "repo_context_hooks" / "bundle" / "templates" / "windsurf-rule.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Resume Checklist" in replit
+    assert "last completed change" in replit
+    assert "next step" in replit
+
+    assert "repo-specific continuity only" in windsurf
+    assert "team-wide or personal Cascade rules" in windsurf
+
+
+def test_lovable_and_openclaw_templates_include_safe_sync_guidance() -> None:
+    lovable_project = (
+        ROOT / "repo_context_hooks" / "bundle" / "templates" / "lovable-project-knowledge.md"
+    ).read_text(encoding="utf-8")
+    lovable_workspace = (
+        ROOT / "repo_context_hooks" / "bundle" / "templates" / "lovable-workspace-knowledge.md"
+    ).read_text(encoding="utf-8")
+    openclaw_soul = (
+        ROOT / "repo_context_hooks" / "bundle" / "templates" / "openclaw-soul.md"
+    ).read_text(encoding="utf-8")
+    openclaw_user = (
+        ROOT / "repo_context_hooks" / "bundle" / "templates" / "openclaw-user.md"
+    ).read_text(encoding="utf-8")
+    openclaw_tools = (
+        ROOT / "repo_context_hooks" / "bundle" / "templates" / "openclaw-tools.md"
+    ).read_text(encoding="utf-8")
+
+    assert "re-paste it into Lovable Project Knowledge" in lovable_project
+    assert "hosted field is a mirror" in lovable_project
+    assert "re-paste it into Lovable Workspace Knowledge" in lovable_workspace
+    assert "repo-owned workspace export" in lovable_workspace
+
+    assert "private workspace" in openclaw_soul
+    assert "private workspace" in openclaw_user
+    assert "private workspace" in openclaw_tools
+
+
+def test_ollama_and_kimi_playbooks_include_examples() -> None:
+    ollama = (
+        ROOT / "repo_context_hooks" / "bundle" / "templates" / "ollama-modelfile"
+    ).read_text(encoding="utf-8")
+    playbooks = (ROOT / "docs" / "platform-playbooks.md").read_text(encoding="utf-8")
+
+    assert "safe smoke test" in ollama.lower()
+    assert "agent wrapper" in ollama.lower()
+
+    assert "### Restart checklist" in playbooks
+    assert "### Layering example" in playbooks
+    assert "### Resync loop" in playbooks
+    assert "### Safe split" in playbooks
+    assert "### Safe smoke test" in playbooks
+    assert "### `/init` merge example" in playbooks


### PR DESCRIPTION
## Summary
Polishes the first wave of partial-platform support by tightening the generated templates and the platform playbooks across Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi.

### What changed
- Replit: adds a resume checklist to `replit.md`.
- Windsurf: adds repo-vs-team rule layering guidance to the Windsurf continuity rule.
- Lovable: makes the repo-owned export -> hosted UI mirror relationship explicit.
- OpenClaw: adds private-workspace guidance to the repo-safe workspace files.
- Ollama: adds agent-wrapper guidance and a safe smoke-test strategy to the Modelfile/playbook.
- Kimi: adds `/init` merge guidance in the playbook.
- Adds `tests/test_platform_polish_contract.py` to keep this guidance from regressing.

### Issues covered
- #2 Replit partial-support follow-up
- #3 Lovable partial-support follow-up
- #4 Ollama partial-support follow-up
- #5 OpenClaw partial-support follow-up
- #6 Kimi partial-support follow-up
- #8 Windsurf partial-support follow-up

### Verification
- `python -m pytest -q --basetemp C:\Users\naren\projects\.tmp\pytest-v0-2-platform-polish-full`
- Result: `86 passed`

### Notes
- Existing untracked local files `UBIQUITOUS_LANGUAGE.md` and `specs/` were left untouched.