### PR TITLE
[codex] release v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repo-context-hooks"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hook-based repo context continuity for coding agents."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/repo_context_hooks/__init__.py
+++ b/repo_context_hooks/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## Summary

- bump package version from `0.1.0` to `0.2.0`
- align the published package version with the completed platform-polish work already merged to `main`

## Validation

- `python -m pytest -q --basetemp .pytest-tmp-release-v0.2.0`
- `python -m pip install -e .`
- `python -c "from pathlib import Path; ns = {}; exec(Path('repo_context_hooks/__init__.py').read_text(), ns); print(ns['__version__'])"`
