### PR TITLE
[codex] track repo memory contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When that happens, the next session has to reconstruct:
 - what tradeoffs were already decided
 - what should happen next
 
-`repo-context-hooks` narrows that problem to a repo contract teams can inspect in git. Product intent stays public in `README.md`. Engineering continuity stays in `specs/README.md`. The agent workflow becomes easier to review, critique, and resume.
+`repo-context-hooks` narrows that problem to a repo contract teams can inspect in git. Product intent stays public in `README.md`. Engineering continuity stays in `specs/README.md`. Shared terminology stays in `UBIQUITOUS_LANGUAGE.md`. The agent workflow becomes easier to review, critique, and resume.
 
 ## How It Works
 
@@ -85,6 +85,8 @@ Without a checked-in continuity contract, teams repeat themselves. With one, the
 ## See Also
 
 - [Platform support](docs/platforms.md)
+- [Engineering memory](specs/README.md)
+- [Ubiquitous language](UBIQUITOUS_LANGUAGE.md)
 - [Platform playbooks](docs/platform-playbooks.md)
 - [Architecture](docs/architecture.md)
 - [Competitive analysis](docs/competitive-analysis.md)

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -1,0 +1,15 @@
+# Ubiquitous Language
+
+Keep project terms stable across code, specs, docs, and conversation.
+
+## Terms
+
+- `repo contract`: the checked-in continuity surface made up of `README.md`, `specs/README.md`, and supporting instruction files such as `AGENTS.md`.
+- `repo-native continuity`: resuming work from repository state instead of relying on chat history alone.
+- `engineering memory`: the implementation-facing context stored in `specs/README.md`, including constraints, decisions, failures, and next work.
+- `support tier`: the explicit level of confidence for a platform integration.
+- `native`: first-class support with the strongest automation surface this product can honestly verify.
+- `partial`: useful repo-context support without full lifecycle or hook parity.
+- `planned`: a documented integration direction that is not yet shipped.
+- `platform playbook`: the platform-specific setup and handoff guidance in `docs/platform-playbooks.md`.
+- Prefer one canonical term per concept.

--- a/docs/superpowers/plans/2026-04-23-repo-memory-contract-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-repo-memory-contract-implementation.md
@@ -1,0 +1,51 @@
+# Repo Memory Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `specs/README.md` and `UBIQUITOUS_LANGUAGE.md` first-class tracked files, reduce noisy auto-generated repo context metadata, and add regression tests for the repo memory contract.
+
+**Architecture:** Promote the repo memory scaffolding into checked-in docs, then adjust the bundled memory sync script so the top-level repo context index stays stable across worktrees. Protect the behavior with small focused tests instead of relying on manual inspection.
+
+**Tech Stack:** Python, pytest, Markdown docs
+
+---
+
+### Task 1: Add canonical repo memory files
+
+**Files:**
+- Create: `UBIQUITOUS_LANGUAGE.md`
+- Create: `specs/README.md`
+- Modify: `README.md`
+
+- [ ] Replace the generated glossary placeholder with real product vocabulary.
+- [ ] Replace the generated engineering-memory placeholder with real `v0.2.0` repo context and next-work guidance.
+- [ ] Update `README.md` so the public repo contract explicitly mentions `UBIQUITOUS_LANGUAGE.md`.
+
+### Task 2: Reduce top-level memory sync noise
+
+**Files:**
+- Modify: `repo_context_hooks/bundle/scripts/repo_specs_memory.py`
+- Modify: `repo_context_hooks/bundle/skills/context-handoff-hooks/scripts/repo_specs_memory.py`
+
+- [ ] Remove branch snapshot and last-commit fields from the top-level auto context block.
+- [ ] Keep explicit checkpoint entries unchanged so compact and session-end events still record tactical state.
+- [ ] Keep the two bundled script copies in sync.
+
+### Task 3: Add regression tests
+
+**Files:**
+- Create: `tests/test_repo_memory_contract.py`
+- Modify: `tests/test_readme_contract.py`
+
+- [ ] Add a contract test for tracked repo memory files and required sections.
+- [ ] Add a script-behavior test proving `session-start` bootstrap does not inject branch/commit noise into the top-level context block.
+- [ ] Extend README contract coverage so the glossary file is treated as part of the public repo contract.
+
+### Task 4: Verify and prepare for publish
+
+**Files:**
+- Modify only files from Tasks 1-3
+
+- [ ] Run `python -m pytest -q --basetemp .pytest-tmp-memory-contract`.
+- [ ] Review `git diff --stat` and `git status --short` to confirm only intended files changed.
+- [ ] Commit with a docs/contract-oriented message once verification is green.

--- a/docs/superpowers/specs/2026-04-23-repo-memory-contract-design.md
+++ b/docs/superpowers/specs/2026-04-23-repo-memory-contract-design.md
@@ -1,0 +1,62 @@
+# Repo Memory Contract Design
+
+## Problem
+
+`repo-context-hooks` treats `README.md`, `specs/README.md`, and `UBIQUITOUS_LANGUAGE.md` as the core repo contract, but this repository does not currently track the latter two files. As a result, fresh worktrees keep accumulating the same generated memory scaffolding as untracked files. The shipped memory sync script also injects branch-specific metadata into the top-level context block, which makes the file feel like disposable session output instead of canonical repo context.
+
+## Goals
+
+- Track `specs/README.md` and `UBIQUITOUS_LANGUAGE.md` in the repository as canonical files.
+- Replace the generic generated memory scaffold with real `repo-context-hooks` project context.
+- Remove branch-specific noise from the script-generated repo context index while preserving checkpoint writes for compact and session-end events.
+- Add tests that protect the repo memory contract and the bundled sync script behavior.
+
+## Non-Goals
+
+- Redesign the broader hook lifecycle.
+- Remove checkpoint logging for `pre-compact`, `post-compact`, or `session-end`.
+- Add new platforms or widen support claims.
+
+## Design
+
+### Canonical repo memory files
+
+Add tracked root files:
+
+- `UBIQUITOUS_LANGUAGE.md`
+- `specs/README.md`
+
+These should stop being empty bootstrap placeholders and instead describe the actual product:
+
+- the repo-native continuity positioning
+- the support-tier model
+- the design constraints that keep public claims honest
+- what shipped in `v0.2.0`
+- what should happen next
+
+### Less noisy auto context block
+
+The auto-generated context block in `repo_specs_memory.py` should stay useful, but it should not include:
+
+- branch snapshot
+- last commit
+
+Those values are session-local and worktree-local. They are still appropriate in explicit checkpoint entries, but not in the top-level canonical context index.
+
+### Test coverage
+
+Add tests for:
+
+- the presence and structure of the tracked repo memory files
+- the README linking the repo contract files explicitly
+- the bundled sync script creating a repo context index without branch/commit noise on `session-start`
+
+## Self-Critique
+
+### Critique 1
+
+If we only track the missing files and leave the bundle script unchanged, we trade untracked noise for noisy tracked diffs. That would look cleaner at first glance but make the repo contract less stable over time.
+
+### Critique 2
+
+If we remove all dynamic metadata, we risk losing useful tactical history. Keeping branch/commit details in explicit checkpoints but not in the top-level context index preserves the operational value without polluting the canonical repo contract.

--- a/repo_context_hooks/bundle/scripts/repo_specs_memory.py
+++ b/repo_context_hooks/bundle/scripts/repo_specs_memory.py
@@ -124,17 +124,13 @@ def ensure_section(content: str, title: str, body: str) -> str:
 
 
 def build_auto_block(repo_root: Path, summary: str, ul_path: Path) -> str:
-    branch = git_output("branch", "--show-current") or "unknown"
-    last_commit = git_output("log", "-1", "--pretty=%s") or "(none)"
-
     return (
         f"{AUTO_BLOCK_START}\n"
         "### Canonical Context Sources\n\n"
         f"- User-facing overview: `README.md`\n"
         f"- Engineering memory: `specs/README.md`\n"
         f"- Glossary: `{ul_path.name}`\n"
-        f"- Branch snapshot: `{branch}`\n"
-        f"- Last commit: `{last_commit}`\n\n"
+        "- Source of truth: checked-in repo docs, not chat-only summaries\n\n"
         "### Repo Summary\n\n"
         f"- {summary}\n"
         f"{AUTO_BLOCK_END}"

--- a/repo_context_hooks/bundle/skills/context-handoff-hooks/scripts/repo_specs_memory.py
+++ b/repo_context_hooks/bundle/skills/context-handoff-hooks/scripts/repo_specs_memory.py
@@ -124,17 +124,13 @@ def ensure_section(content: str, title: str, body: str) -> str:
 
 
 def build_auto_block(repo_root: Path, summary: str, ul_path: Path) -> str:
-    branch = git_output("branch", "--show-current") or "unknown"
-    last_commit = git_output("log", "-1", "--pretty=%s") or "(none)"
-
     return (
         f"{AUTO_BLOCK_START}\n"
         "### Canonical Context Sources\n\n"
         f"- User-facing overview: `README.md`\n"
         f"- Engineering memory: `specs/README.md`\n"
         f"- Glossary: `{ul_path.name}`\n"
-        f"- Branch snapshot: `{branch}`\n"
-        f"- Last commit: `{last_commit}`\n\n"
+        "- Source of truth: checked-in repo docs, not chat-only summaries\n\n"
         "### Repo Summary\n\n"
         f"- {summary}\n"
         f"{AUTO_BLOCK_END}"

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,68 @@
+# Engineering Memory
+
+This file is the persistent project context for agents and maintainers.
+
+
+## Repo Context Index
+
+<!-- AUTO:REPO_CONTEXT_START -->
+### Canonical Context Sources
+
+- User-facing overview: `README.md`
+- Engineering memory: `specs/README.md`
+- Glossary: `UBIQUITOUS_LANGUAGE.md`
+- Source of truth: checked-in repo docs, not chat-only summaries
+
+### Repo Summary
+
+- Repo-native continuity for coding agents. `repo-context-hooks` keeps interrupted work, next-step context, and handoff notes in the repository instead of leaving them trapped in chat history. The goal is simple: a new session should be able to reopen the repo, understand the work in progress, and continue without rediscovering everything from scratch.
+<!-- AUTO:REPO_CONTEXT_END -->
+
+## Architecture and Design Constraints
+
+- Keep the public claim boundary honest. Claude is the native path; the other shipped platforms are partial integrations with documented caveats.
+- Favor repo-native continuity over hosted memory claims. This product should remain inspectable in git and understandable without a separate memory backend.
+- Treat `README.md`, `specs/README.md`, and `UBIQUITOUS_LANGUAGE.md` as durable source-of-truth files, not disposable bootstrap output.
+- Prefer platform-specific adapters and playbooks over generic “supports every agent” language.
+
+## Built So Far
+
+- `v0.2.0` is live with native Claude support plus partial support for Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi.
+- The repo ships platform templates, install flows, doctor checks, playbooks, diagrams, and launch docs.
+- The support matrix is now backed by tests so README claims, platform docs, and templates stay aligned.
+
+## Design Decisions
+
+- Position the product as repo-native continuity, not as a generic AI memory database.
+- Keep the public README outcome-focused and move operator-heavy details into docs and playbooks.
+- Model platform support with explicit tiers (`native`, `partial`, `planned`) instead of broad compatibility claims.
+- Track compatibility aliases (`repo-context-hooks`, `repohandoff`, `graphify`) while keeping the product language centered on `repo-context-hooks`.
+
+## What Worked
+
+- Tight claim boundaries improved trust: each platform is documented according to its real integration surface.
+- Platform-specific adapters plus playbooks made the product more useful without pretending every tool has Claude-style hooks.
+- Contract tests on README, docs, templates, and visuals helped keep product positioning and implementation in sync.
+
+## What Failed or Was Reverted
+
+- Overly internal README sections hurt the public GitHub landing page and had to be removed.
+- Broad “all agents” wording created avoidable trust gaps because the runtime support was narrower than the marketing language.
+- Leaving repo memory files untracked caused repeated worktree noise and made the contract feel optional instead of canonical.
+
+## Open Issues and Next Work
+
+- Keep the repo memory contract canonical and low-noise so future worktrees stop accumulating untracked bootstrap files.
+- Continue raising platform quality through real support surfaces, not expanded marketing copy.
+- Improve launch assets and public examples only when they stay faithful to the implementation boundary.
+
+## How To Work in This Repo
+
+- Read `README.md` first for user-facing behavior and contribution flow.
+- Read this `specs/README.md` before implementation.
+- Read `UBIQUITOUS_LANGUAGE.md` before renaming core concepts or adding new public terms.
+- Keep support claims narrow unless docs, tests, and install behavior all support widening them.
+- Update this file before `compact` and at session end.
+
+## Session Checkpoints
+

--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -67,6 +67,17 @@ def test_readme_points_to_platform_support_doc() -> None:
     assert (ROOT / "docs" / "platforms.md").exists(), "missing docs/platforms.md"
 
 
+def test_readme_points_to_repo_contract_files() -> None:
+    text = readme_text()
+    expected_links = [
+        ("specs/README.md", ROOT / "specs" / "README.md"),
+        ("UBIQUITOUS_LANGUAGE.md", ROOT / "UBIQUITOUS_LANGUAGE.md"),
+    ]
+    for link_text, link_path in expected_links:
+        assert link_text in text, f"missing repo contract link: {link_text}"
+        assert link_path.exists(), f"missing repo contract file: {link_path}"
+
+
 def test_readme_avoids_internal_operator_heavy_sections() -> None:
     text = readme_text()
     unexpected_snippets = [

--- a/tests/test_repo_memory_contract.py
+++ b/tests/test_repo_memory_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPECS = ROOT / "specs" / "README.md"
+GLOSSARY = ROOT / "UBIQUITOUS_LANGUAGE.md"
+SCRIPT = ROOT / "repo_context_hooks" / "bundle" / "scripts" / "repo_specs_memory.py"
+
+
+def _tmp_dir() -> Path:
+    base = ROOT / ".tmp-tests"
+    base.mkdir(exist_ok=True)
+    path = base / uuid4().hex
+    path.mkdir()
+    return path
+
+
+def test_repo_tracks_canonical_memory_files() -> None:
+    assert GLOSSARY.exists(), "missing UBIQUITOUS_LANGUAGE.md"
+    assert SPECS.exists(), "missing specs/README.md"
+
+    glossary = GLOSSARY.read_text(encoding="utf-8")
+    specs = SPECS.read_text(encoding="utf-8")
+
+    expected_terms = [
+        "repo contract",
+        "repo-native continuity",
+        "engineering memory",
+        "support tier",
+        "native",
+        "partial",
+        "planned",
+    ]
+    for term in expected_terms:
+        assert term in glossary, f"missing glossary term: {term}"
+
+    expected_sections = [
+        "## Repo Context Index",
+        "## Architecture and Design Constraints",
+        "## Built So Far",
+        "## Design Decisions",
+        "## What Worked",
+        "## What Failed or Was Reverted",
+        "## Open Issues and Next Work",
+        "## How To Work in This Repo",
+        "## Session Checkpoints",
+    ]
+    for section in expected_sections:
+        assert section in specs, f"missing specs section: {section}"
+
+    assert "Branch snapshot:" not in specs
+    assert "Last commit:" not in specs
+
+
+def test_repo_specs_memory_bootstrap_avoids_branch_and_commit_noise() -> None:
+    temp_root = _tmp_dir()
+    repo = temp_root / "repo"
+    repo.mkdir()
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True, text=True)
+    (repo / "README.md").write_text(
+        "# Demo Repo\n\nDemo repo for testing the repo memory bootstrap behavior.\n",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "session-start"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    specs = (repo / "specs" / "README.md").read_text(encoding="utf-8")
+    glossary = (repo / "UBIQUITOUS_LANGUAGE.md").read_text(encoding="utf-8")
+
+    assert "### Canonical Context Sources" in specs
+    assert "Source of truth: checked-in repo docs, not chat-only summaries" in specs
+    assert "Branch snapshot:" not in specs
+    assert "Last commit:" not in specs
+    assert "Keep project terms stable across code, specs, docs, and conversation." in glossary


### PR DESCRIPTION
## Summary

- track `specs/README.md` and `UBIQUITOUS_LANGUAGE.md` as canonical repo contract files
- update the bundled repo memory sync scripts so the top-level context block no longer injects branch and last-commit noise
- add regression coverage for the repo memory contract and README links

## Validation

- `python -m pytest -q tests/test_repo_memory_contract.py tests/test_readme_contract.py --basetemp .pytest-tmp-memory-focus`
- `python -m pytest -q --basetemp .pytest-tmp-memory-contract`
