### PR TITLE
[codex] add repo-first onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Repo-native continuity for coding agents.
 
 ```bash
 python -m pip install -e .
+repo-context-hooks init
+repo-context-hooks doctor
 repo-context-hooks install --platform claude
 repo-context-hooks install --platform codex
 repo-context-hooks install --platform replit
@@ -17,6 +19,12 @@ repo-context-hooks install --platform kimi
 ```
 
 Current support is intentionally narrow: Claude is the native path, while Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi are useful but partial integrations.
+
+The first-run path is now repo-first:
+
+1. `repo-context-hooks init`
+2. `repo-context-hooks doctor`
+3. `repo-context-hooks install --platform <name>`
 
 ## Why Repo-Native Continuity
 
@@ -39,6 +47,8 @@ The continuity loop is repo-first:
 2. capture useful tactical state before an interruption or compact event
 3. reload from repo state instead of relying on fragile session memory
 4. leave the next session a cleaner handoff than the one you inherited
+
+That is why onboarding now starts with `repo-context-hooks init` and `repo-context-hooks doctor`. The repo contract should exist before any platform-specific install step.
 
 The mechanism depends on platform surfaces that vary by agent. Claude can automate more of the loop. Cursor and Codex still benefit from the same repo contract, but through narrower continuity surfaces.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,12 @@ The repository is the memory boundary. Instead of treating continuity as hidden 
 - shared agent instruction files such as `AGENTS.md` carry the repo contract into Kimi Code CLI workflows without inventing a Kimi-specific rules directory
 - platform-specific automation helps move that state forward between sessions
 
+That is also the onboarding model:
+
+1. run `repo-context-hooks init`
+2. run `repo-context-hooks doctor`
+3. install a platform adapter only after the repo contract exists
+
 ## Current Continuity Surfaces
 
 Current support is intentionally built around nine platforms: Claude, Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi.

--- a/docs/platform-playbooks.md
+++ b/docs/platform-playbooks.md
@@ -1,6 +1,6 @@
 # Platform Playbooks
 
-These playbooks explain what to do after `repo-context-hooks install --platform <name>` for each partial platform.
+These playbooks explain what to do after `repo-context-hooks init`, `repo-context-hooks doctor`, and `repo-context-hooks install --platform <name>` for each partial platform.
 
 Use them as the operating guide for platforms that do not expose Claude-style lifecycle hooks. The core rule is simple: keep `README.md`, `specs/README.md`, and `AGENTS.md` as the repo contract, then map that contract into the strongest real surface each platform exposes.
 

--- a/docs/superpowers/plans/2026-04-23-repo-first-onboarding-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-repo-first-onboarding-implementation.md
@@ -1,0 +1,63 @@
+# Repo-First Onboarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make repo-first onboarding real by adding `init`, adding repo-wide `doctor`, and updating docs/tests so the CLI matches the product story.
+
+**Architecture:** Add a small repo-contract runtime layer used by both `init` and repo-wide `doctor`, then thread the new behavior through the CLI without changing the existing platform adapter model. Keep platform-specific install and diagnose flows as opt-in step 2.
+
+**Tech Stack:** Python, argparse, pytest, Markdown docs
+
+---
+
+### Task 1: Add repo-contract runtime helpers
+
+**Files:**
+- Create: `repo_context_hooks/repo_contract.py`
+- Modify: `repo_context_hooks/installer.py`
+
+- [ ] Add helper functions to create or normalize `README.md`, `specs/README.md`, `UBIQUITOUS_LANGUAGE.md`, and `AGENTS.md`.
+- [ ] Reuse existing bundle templates and memory bootstrap behavior where possible.
+- [ ] Keep default behavior safe: only create missing files unless `force=True`.
+
+### Task 2: Add repo-wide doctor support
+
+**Files:**
+- Modify: `repo_context_hooks/doctor.py`
+- Modify: `repo_context_hooks/cli.py`
+
+- [ ] Add a repo-contract report type and render path.
+- [ ] Make `repo-context-hooks doctor` validate the repo contract when no platform is supplied.
+- [ ] Keep `doctor --platform <id>` working exactly as the platform-specific path.
+
+### Task 3: Add `init` CLI command
+
+**Files:**
+- Modify: `repo_context_hooks/cli.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_doctor.py`
+- Create: `tests/test_repo_contract_runtime.py`
+
+- [ ] Add parser support for `init`.
+- [ ] Implement `init` so it prints statuses for created or skipped files.
+- [ ] Add tests covering `init`, repo-wide doctor, and the safe-by-default non-clobber behavior.
+
+### Task 4: Update docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/platform-playbooks.md`
+
+- [ ] Update quickstart to start with `init`, then repo-wide `doctor`, then platform install.
+- [ ] Explain the repo-first onboarding model in the docs.
+- [ ] Keep public platform claims unchanged.
+
+### Task 5: Verify and publish
+
+**Files:**
+- Modify only files from Tasks 1-4
+
+- [ ] Run `python -m pytest -q --basetemp .pytest-tmp-repo-first-onboarding`.
+- [ ] Review `git diff --stat` and `git status --short`.
+- [ ] Commit, push, and open a PR once verification is green.

--- a/docs/superpowers/specs/2026-04-23-repo-first-onboarding-design.md
+++ b/docs/superpowers/specs/2026-04-23-repo-first-onboarding-design.md
@@ -1,0 +1,127 @@
+# Repo-First Onboarding Design
+
+## Problem
+
+`repo-context-hooks` is positioned as a repo-native continuity product, but the CLI still starts from platform installation. A new user currently has to infer the right order:
+
+1. understand the repo contract
+2. bootstrap the contract files
+3. choose a platform
+4. validate the result
+
+That means the public product story is stronger than the first-run CLI story.
+
+## Goals
+
+- Add a repo-first onboarding command that bootstraps the canonical repo contract.
+- Add a repo-wide diagnostic path that validates the repo contract before platform-specific setup.
+- Keep platform-specific installation and diagnosis intact.
+- Make the docs reflect the new onboarding sequence.
+
+## Non-Goals
+
+- Redesign the platform adapter model.
+- Add new platforms in this phase.
+- Auto-detect and install every possible platform.
+
+## Approaches
+
+### Approach 1: Repo-first onboarding layer
+
+Add a new `init` command and make `doctor` work without a platform argument.
+
+Pros:
+- strongest alignment with the product USP
+- low-risk CLI expansion
+- improves first-run experience without destabilizing platform adapters
+
+Cons:
+- adds one more command to maintain
+
+### Approach 2: Make `install` do everything
+
+Keep a single install command and overload it to bootstrap the repo contract plus platform setup.
+
+Pros:
+- fewer commands
+
+Cons:
+- weak separation between repo setup and platform setup
+- harder to explain and harder to verify
+
+### Approach 3: Docs-only onboarding
+
+Leave the CLI alone and rely on README/playbooks to teach the order of operations.
+
+Pros:
+- smallest code change
+
+Cons:
+- leaves the product gap in place
+- does not make the repo-first story operational
+
+## Recommendation
+
+Use **Approach 1**.
+
+The product promise is repo-native continuity, so the CLI should let users set up the repo contract before they think about adapter choice. Platform installation should become step 2, not step 1.
+
+## Design
+
+### `repo-context-hooks init`
+
+Add a new top-level CLI command:
+
+```bash
+repo-context-hooks init
+```
+
+Behavior:
+
+- create `README.md` if missing
+- create or normalize `specs/README.md`
+- create or normalize `UBIQUITOUS_LANGUAGE.md`
+- create `AGENTS.md` if missing
+- avoid overwriting existing user-authored files unless `--force` is passed
+
+This command should use the same bundle templates and repo-memory bootstrap logic already used elsewhere, but without requiring a Claude-specific hooks install.
+
+### Repo-wide `doctor`
+
+Add a repo-contract diagnosis path:
+
+```bash
+repo-context-hooks doctor
+```
+
+Behavior:
+
+- validate `README.md`
+- validate `specs/README.md`
+- validate `UBIQUITOUS_LANGUAGE.md`
+- warn if `AGENTS.md` is missing
+- return nonzero if the core repo contract is missing or invalid
+
+Platform-specific doctor remains:
+
+```bash
+repo-context-hooks doctor --platform claude
+```
+
+### Docs and quickstart
+
+Update the README quickstart so the onboarding path is:
+
+1. `repo-context-hooks init`
+2. `repo-context-hooks doctor`
+3. `repo-context-hooks install --platform <platform>`
+
+## Self-Critique
+
+### Critique 1
+
+If `init` becomes too aggressive about modifying `README.md`, it will feel like a template generator rather than a continuity tool. This phase should keep `README.md` creation minimal and only fill it in when missing.
+
+### Critique 2
+
+If repo-wide `doctor` tries to infer and validate every platform automatically, it will become noisy and unpredictable. It should stay focused on the repo contract, with platform checks remaining explicit.

--- a/repo_context_hooks/cli.py
+++ b/repo_context_hooks/cli.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from .doctor import diagnose_platform
 from .installer import install_platform, supported_platform_ids
 from .platforms import get_registry
+from .repo_contract import init_repo_contract
+from .doctor import diagnose_repo_contract
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -41,13 +43,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Overwrite existing installed artifacts.",
     )
 
+    init = subparsers.add_parser(
+        "init",
+        help="Bootstrap the canonical repo contract files.",
+    )
+    init.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root to initialize (default: current directory).",
+    )
+    init.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite bootstrapped files when supported.",
+    )
+
     doctor = subparsers.add_parser(
         "doctor",
         help="Validate repo context setup for a platform.",
     )
     doctor.add_argument(
         "--platform",
-        required=True,
         choices=supported_platform_ids(),
         help="Target platform to validate.",
     )
@@ -107,11 +123,26 @@ def _install(args: argparse.Namespace) -> int:
     return 0
 
 
-def _doctor(args: argparse.Namespace) -> int:
-    report = diagnose_platform(
-        args.platform,
-        repo_root=Path(args.repo_root).resolve(),
+def _init(args: argparse.Namespace) -> int:
+    statuses = init_repo_contract(
+        Path(args.repo_root).resolve(),
+        force=args.force,
     )
+    print("Initialized repo contract:")
+    for name, status in statuses.items():
+        print(f"- {name}: {status}")
+    return 0
+
+
+def _doctor(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    if getattr(args, "platform", None):
+        report = diagnose_platform(
+            args.platform,
+            repo_root=repo_root,
+        )
+    else:
+        report = diagnose_repo_contract(repo_root)
     print(report.render())
     return 0 if report.ok else 1
 
@@ -119,6 +150,8 @@ def _doctor(args: argparse.Namespace) -> int:
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
+    if args.command == "init":
+        return _init(args)
     if args.command == "install":
         return _install(args)
     if args.command == "platforms":

--- a/repo_context_hooks/doctor.py
+++ b/repo_context_hooks/doctor.py
@@ -100,6 +100,79 @@ def _matches_expected_markers(path: Path) -> bool:
     return all(marker in text for marker in markers)
 
 
+def _repo_contract_markers(path: Path) -> tuple[str, ...]:
+    path_text = path.as_posix()
+    if path_text.endswith("specs/README.md"):
+        return (
+            "## Repo Context Index",
+            "## Architecture and Design Constraints",
+            "## Open Issues and Next Work",
+            "## How To Work in This Repo",
+            "## Session Checkpoints",
+        )
+    if path.name == "README.md":
+        return ()
+    if path.name == "UBIQUITOUS_LANGUAGE.md":
+        return (
+            "# Ubiquitous Language",
+            "## Terms",
+        )
+    return ()
+
+
+def _matches_repo_contract_markers(path: Path) -> bool:
+    if path.name == "README.md" and path.parent.name != "specs":
+        return bool(path.read_text(encoding="utf-8", errors="ignore").strip())
+
+    markers = _repo_contract_markers(path)
+    if not markers or not path.is_file():
+        return True
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    return all(marker in text for marker in markers)
+
+
+def diagnose_repo_contract(repo_root: Path) -> DoctorReport:
+    repo_root = repo_root.resolve()
+    required = (
+        repo_root / "README.md",
+        repo_root / "specs" / "README.md",
+        repo_root / "UBIQUITOUS_LANGUAGE.md",
+    )
+
+    present: list[str] = []
+    missing: list[str] = []
+    invalid: list[str] = []
+    warnings: list[str] = []
+
+    for path in required:
+        rel = path.relative_to(repo_root).as_posix()
+        if not path.exists():
+            missing.append(rel)
+            continue
+        if _matches_repo_contract_markers(path):
+            present.append(rel)
+        else:
+            invalid.append(rel)
+
+    agents = repo_root / "AGENTS.md"
+    if agents.exists():
+        if _matches_expected_markers(agents):
+            present.append("AGENTS.md")
+        else:
+            warnings.append("AGENTS.md exists but does not clearly reference the repo contract.")
+    else:
+        warnings.append("AGENTS.md is recommended but currently missing.")
+
+    return DoctorReport(
+        platform_id="repo-contract",
+        ok=not missing and not invalid,
+        present=tuple(present),
+        missing=tuple(missing),
+        invalid=tuple(invalid),
+        warnings=tuple(warnings),
+    )
+
+
 def diagnose_platform(
     platform: str,
     repo_root: Path,

--- a/repo_context_hooks/repo_contract.py
+++ b/repo_context_hooks/repo_contract.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .platforms.runtime import render_template
+
+
+AUTO_BLOCK_START = "<!-- AUTO:REPO_CONTEXT_START -->"
+AUTO_BLOCK_END = "<!-- AUTO:REPO_CONTEXT_END -->"
+CHECKPOINTS_HEADING = "## Session Checkpoints"
+
+README_TEMPLATE = """# Project Overview
+
+Describe what this project does for users, how they can use it, and how they can contribute.
+"""
+
+GLOSSARY_TEMPLATE = """# Ubiquitous Language
+
+Keep project terms stable across code, specs, docs, and conversation.
+
+## Terms
+
+- Add domain terms as they are introduced.
+- Prefer one canonical term per concept.
+"""
+
+SECTIONS: list[tuple[str, str]] = [
+    (
+        "Architecture and Design Constraints",
+        "- Document hard constraints: security, latency, data boundaries, platform limits.\n"
+        "- Explicitly call out non-goals so agents do not overbuild.",
+    ),
+    (
+        "Built So Far",
+        "- Summarize current shipped capabilities and important in-progress slices.\n"
+        "- Prefer concrete status over aspiration.",
+    ),
+    (
+        "Design Decisions",
+        "- Record decisions with short rationale and trade-offs.\n"
+        "- Keep this as the canonical ADR-lite trail for this repo.",
+    ),
+    (
+        "What Worked",
+        "- Capture patterns that produced reliable progress and quality.",
+    ),
+    (
+        "What Failed or Was Reverted",
+        "- Capture dead ends, regressions, and reversals so new agents avoid repeats.",
+    ),
+    (
+        "Open Issues and Next Work",
+        "- List open issues, next priority, and implementation order.\n"
+        "- Keep this section actionable and current before compaction.",
+    ),
+    (
+        "How To Work in This Repo",
+        "- Read `README.md` first for user-facing behavior and contribution flow.\n"
+        "- Read this `specs/README.md` before implementation.\n"
+        "- Update this file before `compact` and at session end.",
+    ),
+]
+
+
+def clean_line(line: str) -> str:
+    line = re.sub(r"<[^>]+>", "", line)
+    line = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", line)
+    return line.strip()
+
+
+def extract_repo_summary(repo_root: Path) -> str:
+    readme = repo_root / "README.md"
+    if not readme.exists():
+        return (
+            f"{repo_root.name} is an active project. Keep this repository's user-facing "
+            "README and engineering memory synchronized."
+        )
+
+    lines: list[str] = []
+    for raw in readme.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = clean_line(raw)
+        if not line:
+            continue
+        if line.startswith(("#", "|", "```", ">", "!", "-", "*")):
+            continue
+        if len(line) < 25:
+            continue
+        lines.append(line)
+        if len(lines) == 2:
+            break
+
+    if lines:
+        return " ".join(lines)[:400].rstrip()
+    return f"{repo_root.name} repository. Add a concise project summary to README.md."
+
+
+def ensure_section(content: str, title: str, body: str) -> str:
+    pattern = re.compile(rf"^##\s+{re.escape(title)}\s*$", re.MULTILINE)
+    if pattern.search(content):
+        return content
+
+    suffix = f"\n## {title}\n\n{body}\n"
+    if not content.endswith("\n"):
+        content += "\n"
+    return content + suffix
+
+
+def build_auto_block(summary: str) -> str:
+    return (
+        f"{AUTO_BLOCK_START}\n"
+        "### Canonical Context Sources\n\n"
+        "- User-facing overview: `README.md`\n"
+        "- Engineering memory: `specs/README.md`\n"
+        "- Glossary: `UBIQUITOUS_LANGUAGE.md`\n"
+        "- Source of truth: checked-in repo docs, not chat-only summaries\n\n"
+        "### Repo Summary\n\n"
+        f"- {summary}\n"
+        f"{AUTO_BLOCK_END}"
+    )
+
+
+def ensure_readme(repo_root: Path, force: bool = False) -> str:
+    path = repo_root / "README.md"
+    if path.exists() and not force:
+        return "skipped"
+    path.write_text(README_TEMPLATE, encoding="utf-8")
+    return "installed"
+
+
+def ensure_ubiquitous_language(repo_root: Path, force: bool = False) -> str:
+    path = repo_root / "UBIQUITOUS_LANGUAGE.md"
+    if path.exists() and not force:
+        return "skipped"
+    path.write_text(GLOSSARY_TEMPLATE, encoding="utf-8")
+    return "installed"
+
+
+def ensure_agents(repo_root: Path, force: bool = False) -> str:
+    path = repo_root / "AGENTS.md"
+    if path.exists() and not force:
+        return "skipped"
+    path.write_text(render_template("AGENTS.md"), encoding="utf-8")
+    return "installed"
+
+
+def ensure_specs_readme(repo_root: Path, force: bool = False) -> str:
+    specs_dir = repo_root / "specs"
+    specs_dir.mkdir(exist_ok=True)
+    path = specs_dir / "README.md"
+
+    if force and path.exists():
+        path.unlink()
+
+    if not path.exists():
+        path.write_text(
+            "# Engineering Memory\n\n"
+            "This file is the persistent project context for agents and maintainers.\n\n",
+            encoding="utf-8",
+        )
+        created = True
+    else:
+        created = False
+
+    summary = extract_repo_summary(repo_root)
+    content = path.read_text(encoding="utf-8", errors="ignore")
+    auto_block = build_auto_block(summary)
+
+    if AUTO_BLOCK_START in content and AUTO_BLOCK_END in content:
+        pattern = re.compile(
+            rf"{re.escape(AUTO_BLOCK_START)}.*?{re.escape(AUTO_BLOCK_END)}",
+            re.DOTALL,
+        )
+        updated = pattern.sub(auto_block, content)
+    else:
+        updated = content
+        if not updated.endswith("\n"):
+            updated += "\n"
+        updated += "\n## Repo Context Index\n\n" + auto_block + "\n"
+
+    for title, body in SECTIONS:
+        updated = ensure_section(updated, title, body)
+
+    if CHECKPOINTS_HEADING not in updated:
+        if not updated.endswith("\n"):
+            updated += "\n"
+        updated += f"\n{CHECKPOINTS_HEADING}\n\n"
+
+    if updated != content:
+        path.write_text(updated, encoding="utf-8")
+        if created:
+            return "installed"
+        return "updated"
+    return "installed" if created else "skipped"
+
+
+def init_repo_contract(repo_root: Path, force: bool = False) -> dict[str, str]:
+    repo_root = repo_root.resolve()
+    repo_root.mkdir(parents=True, exist_ok=True)
+
+    return {
+        "README.md": ensure_readme(repo_root, force=force),
+        "specs/README.md": ensure_specs_readme(repo_root, force=force),
+        "UBIQUITOUS_LANGUAGE.md": ensure_ubiquitous_language(repo_root, force=force),
+        "AGENTS.md": ensure_agents(repo_root, force=force),
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
-from repo_context_hooks.cli import _doctor, _install, _platforms, build_parser
+from repo_context_hooks.cli import _doctor, _init, _install, _platforms, build_parser
 from repo_context_hooks.doctor import DoctorReport
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,6 +30,8 @@ def test_parser_supports_platforms_and_doctor_commands() -> None:
 
     assert parser.parse_args(["platforms"]).command == "platforms"
     assert parser.parse_args(["doctor", "--platform", "claude"]).command == "doctor"
+    assert parser.parse_args(["doctor"]).command == "doctor"
+    assert parser.parse_args(["init"]).command == "init"
 
 
 def test_platforms_print_support_tiers(capsys) -> None:
@@ -162,3 +164,34 @@ def test_doctor_returns_nonzero_for_missing_state(
     assert _doctor(args) == 1
     out = capsys.readouterr().out
     assert "repo-context-continuity.mdc" in out
+
+
+def test_init_prints_repo_contract_statuses(
+    monkeypatch,
+    capsys,
+) -> None:
+    tmp_path = _tmp_dir()
+
+    def fake_init_repo_contract(repo_root, force: bool = False):
+        return {
+            "README.md": "installed",
+            "specs/README.md": "installed",
+            "UBIQUITOUS_LANGUAGE.md": "installed",
+            "AGENTS.md": "skipped",
+        }
+
+    monkeypatch.setattr(
+        "repo_context_hooks.cli.init_repo_contract",
+        fake_init_repo_contract,
+    )
+
+    args = Namespace(
+        repo_root=str(tmp_path),
+        force=False,
+    )
+
+    assert _init(args) == 0
+    out = capsys.readouterr().out
+    assert "Initialized repo contract" in out
+    assert "README.md: installed" in out
+    assert "AGENTS.md: skipped" in out

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import uuid4
 
-from repo_context_hooks.doctor import diagnose_platform
+from repo_context_hooks.doctor import diagnose_platform, diagnose_repo_contract
 from repo_context_hooks.installer import install_platform
+from repo_context_hooks.repo_contract import init_repo_contract
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -22,6 +23,49 @@ def _write_repo_contract(repo: Path) -> None:
     specs_dir = repo / "specs"
     specs_dir.mkdir()
     (specs_dir / "README.md").write_text("# Specs\n", encoding="utf-8")
+
+
+def test_repo_doctor_reports_missing_contract_files() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    report = diagnose_repo_contract(repo)
+
+    assert report.ok is False
+    assert "README.md" in report.missing
+    assert "specs/README.md" in report.missing
+    assert "UBIQUITOUS_LANGUAGE.md" in report.missing
+    assert "MISSING" in report.render()
+
+
+def test_repo_doctor_reports_initialized_contract() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+
+    report = diagnose_repo_contract(repo)
+
+    assert report.ok is True
+    assert "README.md" in report.present
+    assert "specs/README.md" in report.present
+    assert "UBIQUITOUS_LANGUAGE.md" in report.present
+    assert "AGENTS.md" in report.present
+
+
+def test_repo_doctor_rejects_placeholder_specs_readme() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+    (repo / "specs" / "README.md").write_text("placeholder\n", encoding="utf-8")
+
+    report = diagnose_repo_contract(repo)
+
+    assert report.ok is False
+    assert "specs/README.md" in report.invalid
+    assert "INVALID" in report.render()
 
 
 def test_doctor_reports_missing_cursor_rule() -> None:

--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -78,6 +78,22 @@ def test_readme_points_to_repo_contract_files() -> None:
         assert link_path.exists(), f"missing repo contract file: {link_path}"
 
 
+def test_readme_promotes_repo_first_onboarding_sequence() -> None:
+    text = readme_text()
+    expected_commands = [
+        "repo-context-hooks init",
+        "repo-context-hooks doctor",
+        "repo-context-hooks install --platform claude",
+    ]
+    positions = []
+    for command in expected_commands:
+        position = text.find(command)
+        assert position != -1, f"missing onboarding command: {command}"
+        positions.append(position)
+
+    assert positions == sorted(positions), "README onboarding commands are out of order"
+
+
 def test_readme_avoids_internal_operator_heavy_sections() -> None:
     text = readme_text()
     unexpected_snippets = [

--- a/tests/test_repo_contract_runtime.py
+++ b/tests/test_repo_contract_runtime.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from repo_context_hooks.repo_contract import init_repo_contract
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _tmp_dir() -> Path:
+    base = ROOT / ".tmp-tests"
+    base.mkdir(exist_ok=True)
+    path = base / uuid4().hex
+    path.mkdir()
+    return path
+
+
+def test_init_repo_contract_creates_missing_files() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    statuses = init_repo_contract(repo)
+
+    assert statuses["README.md"] == "installed"
+    assert statuses["specs/README.md"] == "installed"
+    assert statuses["UBIQUITOUS_LANGUAGE.md"] == "installed"
+    assert statuses["AGENTS.md"] == "installed"
+
+    assert (repo / "README.md").exists()
+    assert (repo / "specs" / "README.md").exists()
+    assert (repo / "UBIQUITOUS_LANGUAGE.md").exists()
+    assert (repo / "AGENTS.md").exists()
+
+
+def test_init_repo_contract_preserves_existing_readme_without_force() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    readme = repo / "README.md"
+    readme.write_text("# Custom\n\nKeep me.\n", encoding="utf-8")
+
+    statuses = init_repo_contract(repo, force=False)
+
+    assert statuses["README.md"] == "skipped"
+    assert readme.read_text(encoding="utf-8") == "# Custom\n\nKeep me.\n"


### PR DESCRIPTION
## Summary

- add `repo-context-hooks init` as a repo-first onboarding entrypoint
- add repo-wide `doctor` support so the repo contract can be validated before choosing a platform
- update README and docs so onboarding now flows from `init` to `doctor` to `install --platform ...`

## Validation

- `python -m pytest -q --basetemp .pytest-tmp-repo-first-onboarding`
- `python -m pip install -e .`
- `repo-context-hooks init --repo-root <temp-dir>`
- `repo-context-hooks doctor --repo-root <temp-dir>`
