### PR TITLE
feat: add platform readiness commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Repo-native continuity for coding agents.
 python -m pip install -e .
 repo-context-hooks init
 repo-context-hooks doctor
+repo-context-hooks doctor --all-platforms
+repo-context-hooks recommend
 repo-context-hooks install --platform claude
 repo-context-hooks install --platform codex
 repo-context-hooks install --platform replit
@@ -24,7 +26,11 @@ The first-run path is now repo-first:
 
 1. `repo-context-hooks init`
 2. `repo-context-hooks doctor`
-3. `repo-context-hooks install --platform <name>`
+3. `repo-context-hooks doctor --all-platforms`
+4. `repo-context-hooks recommend`
+5. `repo-context-hooks install --platform <name>`
+
+`doctor` answers "is the repo contract healthy?" `doctor --all-platforms` answers "which supported platforms are actually ready?" `recommend` answers "what should I do next in this repo?"
 
 ## Why Repo-Native Continuity
 
@@ -75,6 +81,20 @@ The support tiers are `native`, `partial`, and `planned`.
 See [docs/platforms.md](docs/platforms.md) for the support matrix, platform-specific caveats, and the current claim boundary. The short version is that we do not claim universal agent support, and we do not claim hook parity or compact automation for Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, or Kimi.
 
 For exact post-install steps on each partial platform, see [docs/platform-playbooks.md](docs/platform-playbooks.md).
+
+## Readiness And Recommendations
+
+Use the new repo-first commands together:
+
+```bash
+repo-context-hooks doctor --all-platforms
+repo-context-hooks recommend
+```
+
+- `doctor --all-platforms` prints a compact readiness matrix across the current support matrix.
+- `recommend` ranks the best next setup paths for the current repo, prints the repo signals it used, and gives the exact next install command to run.
+
+That combination keeps the product honest: readiness is verification, recommendation is advice, and neither widens the public support claim.
 
 ## Concrete Stories
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -31,6 +31,23 @@ Use the matrix above as the public boundary for support claims:
 
 For step-by-step post-install guidance, use [docs/platform-playbooks.md](platform-playbooks.md).
 
+## Readiness Commands
+
+Use the platform support matrix with the new CLI surface:
+
+```bash
+repo-context-hooks doctor --all-platforms
+repo-context-hooks recommend
+```
+
+- `doctor --all-platforms` verifies the repo contract first, then prints one compact readiness row per supported platform.
+- `recommend` inspects visible repo signals and ranks the strongest next setup paths without auto-installing anything.
+
+These commands are complementary:
+
+- use `doctor --all-platforms` when you want a support-wide verification snapshot
+- use `recommend` when you want the shortest credible next step for the current repo
+
 ## How To Read The Matrix
 
 A platform can still be valuable at `partial` tier. The product promise is not "every agent exposes the same primitives." The promise is that the repo can remain the continuity boundary even when the automation surface changes.

--- a/docs/superpowers/plans/2026-04-23-platform-readiness-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-platform-readiness-implementation.md
@@ -1,0 +1,61 @@
+# Platform Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a readiness matrix with `doctor --all-platforms` and a transparent `recommend` command that suggests the next best setup path for the current repo.
+
+**Architecture:** Extend the doctor layer with a multi-platform summary report, then add a small recommendation module that scores visible repo signals and prints transparent next-step guidance. Keep the platform adapter model unchanged and reuse the existing repo-contract and platform doctor behavior as the source of truth.
+
+**Tech Stack:** Python, argparse, pytest, Markdown docs
+
+---
+
+### Task 1: Add failing tests for the new CLI surface
+
+**Files:**
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_doctor.py`
+- Create: `tests/test_recommend.py`
+
+- [ ] Add parser tests for `doctor --all-platforms` and `recommend`.
+- [ ] Add CLI behavior tests for the matrix summary output.
+- [ ] Add recommendation tests for missing repo contract, repo-contract-only repos, and repos with platform-specific signals.
+
+### Task 2: Add multi-platform doctor support
+
+**Files:**
+- Modify: `repo_context_hooks/doctor.py`
+- Modify: `repo_context_hooks/cli.py`
+
+- [ ] Add report models for platform readiness rows and multi-platform summaries.
+- [ ] Build `doctor --all-platforms` from the existing repo-contract and platform doctor checks.
+- [ ] Keep the existing single-platform doctor path intact.
+
+### Task 3: Add recommendation runtime
+
+**Files:**
+- Create: `repo_context_hooks/recommend.py`
+- Modify: `repo_context_hooks/cli.py`
+
+- [ ] Detect explicit repo signals for each supported platform.
+- [ ] Score platforms based on support tier plus detected repo signals.
+- [ ] Print ranked recommendations with reasons and exact next commands.
+
+### Task 4: Update docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/platforms.md`
+
+- [ ] Add the new commands to the public onboarding flow.
+- [ ] Explain the difference between readiness checks and recommendations.
+- [ ] Keep the support matrix and claim boundary unchanged.
+
+### Task 5: Verify and publish
+
+**Files:**
+- Modify only files from Tasks 1-4
+
+- [ ] Run `python -m pytest -q --basetemp .pytest-tmp-platform-readiness`.
+- [ ] Smoke-test `repo-context-hooks doctor --all-platforms` and `repo-context-hooks recommend` against a temp repo.
+- [ ] Commit, push, and open a PR once verification is green.

--- a/docs/superpowers/specs/2026-04-23-platform-readiness-design.md
+++ b/docs/superpowers/specs/2026-04-23-platform-readiness-design.md
@@ -1,0 +1,148 @@
+# Platform Readiness Design
+
+## Problem
+
+`repo-context-hooks` now has a repo-first onboarding flow, but after `init` and repo-wide `doctor`, users still have to manually inspect the platform matrix and infer what to do next. That leaves two gaps:
+
+- no single command shows repo-contract health plus platform readiness across the full support matrix
+- no command explains which platform path is the best fit for the current repo and why
+
+## Goals
+
+- Add `repo-context-hooks doctor --all-platforms` to show a concise readiness matrix.
+- Add `repo-context-hooks recommend` to suggest the best next setup path for the current repo.
+- Keep recommendations transparent and grounded in visible repo signals.
+- Keep support claims unchanged.
+
+## Non-Goals
+
+- Auto-install a platform.
+- Add new platform adapters in this phase.
+- Claim that all supported platforms are equally capable.
+
+## Approaches
+
+### Approach 1: Readiness matrix plus separate recommend command
+
+Add:
+
+- `repo-context-hooks doctor --all-platforms`
+- `repo-context-hooks recommend`
+
+Pros:
+- clear separation between verification and advice
+- easy to keep output compact
+- strongest fit for the repo-first onboarding story
+
+Cons:
+- one more command to teach
+
+### Approach 2: Put recommendations into `doctor`
+
+Extend `doctor` to both diagnose and suggest next steps.
+
+Pros:
+- fewer commands
+
+Cons:
+- mixed responsibilities
+- harder to keep output scannable
+
+### Approach 3: Recommendation-only
+
+Skip the matrix and only give ranked suggestions.
+
+Pros:
+- fastest to implement
+
+Cons:
+- hides platform-by-platform state
+- weaker debugging value
+
+## Recommendation
+
+Use **Approach 1**.
+
+The matrix answers “what is ready?” The recommendation answers “what should I do next?” Those are related but not identical questions, and separating them keeps both outputs useful.
+
+## Design
+
+### `doctor --all-platforms`
+
+Add an optional flag to the existing doctor command:
+
+```bash
+repo-context-hooks doctor --all-platforms
+```
+
+Behavior:
+
+- show repo-contract status first
+- evaluate every currently supported platform
+- print one compact line per platform
+
+Each row should include:
+
+- platform id
+- support tier
+- overall readiness state
+- one concise detail field for the first missing or invalid artifact
+
+The readiness states should be:
+
+- `ready`: no missing or invalid artifacts
+- `missing`: one or more required artifacts are absent
+- `invalid`: required artifacts exist but fail marker validation
+
+Warnings should stay visible but compact.
+
+### `recommend`
+
+Add:
+
+```bash
+repo-context-hooks recommend
+```
+
+Behavior:
+
+- inspect repo signals such as:
+  - `.claude/settings.json`
+  - `.windsurf/rules/`
+  - `replit.md`
+  - `.lovable/`
+  - `SOUL.md`, `USER.md`, `TOOLS.md`
+  - `Modelfile.repo-context`
+  - `AGENTS.md`
+- weight support tier and explicit repo signals
+- print the top recommendations with reasons and exact next commands
+
+If the repo contract is missing or invalid, the command should recommend:
+
+1. `repo-context-hooks init`
+2. `repo-context-hooks doctor`
+
+before platform-specific actions.
+
+If the repo contract is valid and no platform-specific signals are present, the command should prefer the strongest default path:
+
+1. Claude
+2. Cursor or Codex as repo-contract-friendly partial paths
+
+### Transparency
+
+Recommendations must include:
+
+- why the platform ranked where it did
+- which repo signals contributed
+- the next exact command to run
+
+## Self-Critique
+
+### Critique 1
+
+`doctor --all-platforms` can become noisy if it prints full report bodies for every platform. The safe version is a matrix summary plus concise warning text, not a repeated full doctor block.
+
+### Critique 2
+
+`recommend` will feel arbitrary if it only prints rankings. The reasons and signals need to be explicit so developers can disagree intelligently instead of treating the command like opaque magic.

--- a/repo_context_hooks/cli.py
+++ b/repo_context_hooks/cli.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from .doctor import diagnose_platform
+from .doctor import diagnose_all_platforms, diagnose_platform
 from .installer import install_platform, supported_platform_ids
 from .platforms import get_registry
+from .recommend import recommend_setup
 from .repo_contract import init_repo_contract
 from .doctor import diagnose_repo_contract
 
@@ -62,15 +63,37 @@ def build_parser() -> argparse.ArgumentParser:
         "doctor",
         help="Validate repo context setup for a platform.",
     )
-    doctor.add_argument(
+    doctor_scope = doctor.add_mutually_exclusive_group()
+    doctor_scope.add_argument(
         "--platform",
         choices=supported_platform_ids(),
         help="Target platform to validate.",
+    )
+    doctor_scope.add_argument(
+        "--all-platforms",
+        action="store_true",
+        help="Validate repo contract health plus readiness across all supported platforms.",
     )
     doctor.add_argument(
         "--repo-root",
         default=".",
         help="Repository root to inspect (default: current directory).",
+    )
+
+    recommend = subparsers.add_parser(
+        "recommend",
+        help="Recommend the next best platform setup path for this repo.",
+    )
+    recommend.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root to inspect (default: current directory).",
+    )
+    recommend.add_argument(
+        "--limit",
+        type=int,
+        default=3,
+        help="Maximum number of platform recommendations to print (default: 3).",
     )
 
     subparsers.add_parser(
@@ -136,7 +159,9 @@ def _init(args: argparse.Namespace) -> int:
 
 def _doctor(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
-    if getattr(args, "platform", None):
+    if getattr(args, "all_platforms", False):
+        report = diagnose_all_platforms(repo_root=repo_root)
+    elif getattr(args, "platform", None):
         report = diagnose_platform(
             args.platform,
             repo_root=repo_root,
@@ -145,6 +170,13 @@ def _doctor(args: argparse.Namespace) -> int:
         report = diagnose_repo_contract(repo_root)
     print(report.render())
     return 0 if report.ok else 1
+
+
+def _recommend(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    report = recommend_setup(repo_root=repo_root, limit=args.limit)
+    print(report.render())
+    return 0
 
 
 def main() -> int:
@@ -158,5 +190,7 @@ def main() -> int:
         return _platforms()
     if args.command == "doctor":
         return _doctor(args)
+    if args.command == "recommend":
+        return _recommend(args)
     parser.error("Unknown command")
     return 2

--- a/repo_context_hooks/doctor.py
+++ b/repo_context_hooks/doctor.py
@@ -30,6 +30,95 @@ class DoctorReport:
         return "\n".join(lines)
 
 
+@dataclass(frozen=True)
+class PlatformReadinessRow:
+    platform_id: str
+    support_tier: str
+    state: str
+    detail: str = "-"
+    warnings: tuple[str, ...] = ()
+
+    @classmethod
+    def from_report(
+        cls,
+        platform_id: str,
+        support_tier: str,
+        report: DoctorReport,
+        repo_root: Path,
+        home: Path | None = None,
+    ) -> "PlatformReadinessRow":
+        if report.invalid:
+            state = "invalid"
+            detail = _compact_detail(report.invalid[0], repo_root=repo_root, home=home)
+        elif report.missing:
+            state = "missing"
+            detail = _compact_detail(report.missing[0], repo_root=repo_root, home=home)
+        else:
+            state = "ready"
+            detail = (
+                _compact_detail(report.present[0], repo_root=repo_root, home=home)
+                if report.present
+                else "-"
+            )
+        return cls(
+            platform_id=platform_id,
+            support_tier=support_tier,
+            state=state,
+            detail=detail,
+            warnings=report.warnings,
+        )
+
+
+@dataclass(frozen=True)
+class AllPlatformsReport:
+    ok: bool
+    repo_contract: DoctorReport
+    rows: tuple[PlatformReadinessRow, ...]
+
+    def render(self) -> str:
+        status = "OK" if self.ok else "INVALID"
+        repo_state = "ok"
+        if self.repo_contract.invalid:
+            repo_state = "invalid"
+        elif self.repo_contract.missing:
+            repo_state = "missing"
+
+        repo_detail = "-"
+        if self.repo_contract.invalid:
+            repo_detail = self.repo_contract.invalid[0]
+        elif self.repo_contract.missing:
+            repo_detail = self.repo_contract.missing[0]
+
+        lines = [f"[{status}] platform-readiness", f"repo-contract\t{repo_state}\t{repo_detail}"]
+        lines.extend(
+            f"{row.platform_id}\t{row.support_tier}\t{row.state}\t{row.detail}"
+            for row in self.rows
+        )
+        lines.extend(
+            f"warning[{row.platform_id}]: {warning}"
+            for row in self.rows
+            for warning in row.warnings
+        )
+        return "\n".join(lines)
+
+
+def _compact_detail(item: str, repo_root: Path, home: Path | None = None) -> str:
+    path = Path(item)
+    if not path.is_absolute():
+        return item.replace("\\", "/")
+
+    if home is not None:
+        try:
+            return f"home:{path.relative_to(home.resolve()).as_posix()}"
+        except ValueError:
+            pass
+
+    try:
+        return f"repo:{path.relative_to(repo_root.resolve()).as_posix()}"
+    except ValueError:
+        return path.as_posix()
+
+
 def _required_markers(path: Path) -> tuple[str, ...]:
     if path.name == "AGENTS.md":
         return (
@@ -201,4 +290,33 @@ def diagnose_platform(
         missing=tuple(missing),
         invalid=tuple(invalid),
         warnings=plan.warnings,
+    )
+
+
+def diagnose_all_platforms(
+    repo_root: Path,
+    home: Path | None = None,
+) -> AllPlatformsReport:
+    repo_root = repo_root.resolve()
+    repo_report = diagnose_repo_contract(repo_root)
+
+    rows: list[PlatformReadinessRow] = []
+    has_invalid_platform = False
+    for adapter in get_registry().all():
+        report = diagnose_platform(adapter.id, repo_root=repo_root, home=home)
+        row = PlatformReadinessRow.from_report(
+            platform_id=adapter.id,
+            support_tier=adapter.support_tier.value,
+            report=report,
+            repo_root=repo_root,
+            home=home,
+        )
+        if row.state == "invalid":
+            has_invalid_platform = True
+        rows.append(row)
+
+    return AllPlatformsReport(
+        ok=repo_report.ok and not has_invalid_platform,
+        repo_contract=repo_report,
+        rows=tuple(rows),
     )

--- a/repo_context_hooks/recommend.py
+++ b/repo_context_hooks/recommend.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .doctor import diagnose_repo_contract
+from .platforms import get_registry
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    platform_id: str
+    score: int
+    reasons: tuple[str, ...]
+    signals: tuple[str, ...]
+    next_command: str
+
+
+@dataclass(frozen=True)
+class RecommendationReport:
+    repo_contract_ok: bool
+    repo_contract_detail: str
+    detected_signals: tuple[str, ...]
+    recommendations: tuple[Recommendation, ...]
+    preflight_commands: tuple[str, ...] = ()
+
+    def render(self) -> str:
+        lines = ["[RECOMMEND]"]
+        repo_state = "ok" if self.repo_contract_ok else "attention-needed"
+        lines.append(f"Repo contract: {repo_state} ({self.repo_contract_detail})")
+
+        if self.detected_signals:
+            lines.append("Detected signals:")
+            lines.extend(f"- {signal}" for signal in self.detected_signals)
+        else:
+            lines.append("Detected signals:")
+            lines.append("- none")
+
+        if self.preflight_commands:
+            lines.append("Before platform installs:")
+            for index, command in enumerate(self.preflight_commands, start=1):
+                lines.append(f"{index}. {command}")
+            return "\n".join(lines)
+
+        for index, recommendation in enumerate(self.recommendations, start=1):
+            lines.append(f"{index}. {recommendation.platform_id}")
+            for reason in recommendation.reasons:
+                lines.append(f"   Why: {reason}")
+            lines.append(f"   Next: {recommendation.next_command}")
+        return "\n".join(lines)
+
+
+_BASE_SCORES = {
+    "native": 40,
+    "partial": 20,
+    "planned": 0,
+}
+
+_DEFAULT_BONUS = {
+    "claude": 6,
+    "codex": 4,
+    "cursor": 3,
+    "replit": 2,
+    "windsurf": 2,
+    "lovable": 2,
+    "openclaw": 1,
+    "ollama": 1,
+    "kimi": 1,
+}
+
+_SIGNAL_RULES = {
+    "claude": ((".claude/settings.json", "Detected repo signal: .claude/settings.json"),),
+    "cursor": (
+        (".cursor/rules/repo-context-continuity.mdc", "Detected repo signal: .cursor/rules/repo-context-continuity.mdc"),
+        (".cursor", "Detected repo signal: .cursor/"),
+    ),
+    "codex": (
+        (".codex", "Detected repo signal: .codex/"),
+    ),
+    "replit": (("replit.md", "Detected repo signal: replit.md"),),
+    "windsurf": (
+        (".windsurf/rules/repo-context-continuity.md", "Detected repo signal: .windsurf/rules/repo-context-continuity.md"),
+        (".windsurf", "Detected repo signal: .windsurf/"),
+    ),
+    "lovable": (
+        (".lovable/project-knowledge.md", "Detected repo signal: .lovable/project-knowledge.md"),
+        (".lovable/workspace-knowledge.md", "Detected repo signal: .lovable/workspace-knowledge.md"),
+        (".lovable", "Detected repo signal: .lovable/"),
+    ),
+    "openclaw": (
+        ("SOUL.md", "Detected repo signal: SOUL.md"),
+        ("USER.md", "Detected repo signal: USER.md"),
+        ("TOOLS.md", "Detected repo signal: TOOLS.md"),
+    ),
+    "ollama": (("Modelfile.repo-context", "Detected repo signal: Modelfile.repo-context"),),
+    "kimi": ((".kimi", "Detected repo signal: .kimi/"),),
+}
+
+
+def _path_exists(repo_root: Path, relative_path: str) -> bool:
+    return (repo_root / relative_path).exists()
+
+
+def _platform_signals(repo_root: Path, platform_id: str) -> tuple[str, ...]:
+    signals: list[str] = []
+    for relative_path, message in _SIGNAL_RULES.get(platform_id, ()):
+        if _path_exists(repo_root, relative_path):
+            signals.append(message)
+    return tuple(signals)
+
+
+def recommend_setup(repo_root: Path, limit: int = 3) -> RecommendationReport:
+    repo_root = repo_root.resolve()
+    repo_report = diagnose_repo_contract(repo_root)
+
+    if not repo_report.ok:
+        detail = "repo contract is missing or invalid"
+        if repo_report.invalid:
+            detail = f"invalid: {repo_report.invalid[0]}"
+        elif repo_report.missing:
+            detail = f"missing: {repo_report.missing[0]}"
+        return RecommendationReport(
+            repo_contract_ok=False,
+            repo_contract_detail=detail,
+            detected_signals=(),
+            recommendations=(),
+            preflight_commands=(
+                "repo-context-hooks init --repo-root .",
+                "repo-context-hooks doctor --repo-root .",
+            ),
+        )
+
+    recommendations: list[Recommendation] = []
+    all_detected_signals: list[str] = []
+    for adapter in get_registry().all():
+        signals = _platform_signals(repo_root, adapter.id)
+        all_detected_signals.extend(signals)
+
+        score = _BASE_SCORES[adapter.support_tier.value] + _DEFAULT_BONUS.get(adapter.id, 0)
+        reasons = [f"{adapter.metadata.display_name} is {adapter.support_tier.value} support."]
+        if signals:
+            score += 50 + (len(signals) * 5)
+            reasons.append("Detected repo signal(s) that already match this platform.")
+        else:
+            reasons.append("No platform-specific artifacts detected yet; using the default support ranking.")
+
+        recommendations.append(
+            Recommendation(
+                platform_id=adapter.id,
+                score=score,
+                reasons=tuple(reasons + list(signals)),
+                signals=signals,
+                next_command=f"repo-context-hooks install --platform {adapter.id} --repo-root .",
+            )
+        )
+
+    ranked = sorted(
+        recommendations,
+        key=lambda item: (-item.score, item.platform_id),
+    )
+    return RecommendationReport(
+        repo_contract_ok=True,
+        repo_contract_detail="repo contract is healthy",
+        detected_signals=tuple(dict.fromkeys(all_detected_signals)),
+        recommendations=tuple(ranked[:limit]),
+    )

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,7 +1,6 @@
-# Engineering Memory
+﻿# Engineering Memory
 
 This file is the persistent project context for agents and maintainers.
-
 
 ## Repo Context Index
 
@@ -23,13 +22,94 @@ This file is the persistent project context for agents and maintainers.
 - Keep the public claim boundary honest. Claude is the native path; the other shipped platforms are partial integrations with documented caveats.
 - Favor repo-native continuity over hosted memory claims. This product should remain inspectable in git and understandable without a separate memory backend.
 - Treat `README.md`, `specs/README.md`, and `UBIQUITOUS_LANGUAGE.md` as durable source-of-truth files, not disposable bootstrap output.
-- Prefer platform-specific adapters and playbooks over generic “supports every agent” language.
+- Prefer platform-specific adapters and playbooks over generic "supports every agent" language.
 
 ## Built So Far
 
-- `v0.2.0` is live with native Claude support plus partial support for Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi.
-- The repo ships platform templates, install flows, doctor checks, playbooks, diagrams, and launch docs.
-- The support matrix is now backed by tests so README claims, platform docs, and templates stay aligned.
+- We turned an internal continuity workflow into a public open source product named `repo-context-hooks`.
+- The product is intentionally positioned around repo-native continuity for coding agents rather than generic "AI memory" claims.
+- We shipped a real install/runtime surface with three command names that resolve to the same product:
+  - `repo-context-hooks`
+  - `repohandoff`
+  - `graphify`
+- We built and documented credible support for:
+  - Claude (`native`)
+  - Cursor (`partial`)
+  - Codex (`partial`)
+  - Replit (`partial`)
+  - Windsurf (`partial`)
+  - Lovable (`partial`)
+  - OpenClaw (`partial`)
+  - Ollama (`partial`)
+  - Kimi (`partial`)
+- We also shipped the surrounding product surface:
+  - installer flows
+  - repo contract bootstrap
+  - doctor checks
+  - platform playbooks
+  - diagrams
+  - launch copy
+  - roadmap/issues
+- Releases completed so far:
+  - `v0.1.0`: initial public platform foundation
+  - `v0.2.0`: platform polish and consolidation
+  - `v0.2.1`: canonical repo memory contract plus repo-first onboarding
+- Current active branch adds the next layer:
+  - `doctor --all-platforms`
+  - `recommend`
+
+## Delivery Timeline
+
+### Phase 1: Product Identity
+
+- We renamed and repositioned the project until the public name matched what the product actually does.
+- We rejected vague memory-platform language because it overlapped with existing products and would have overpromised the implementation.
+- We settled on a sharper product story: repo-native continuity, interruption-safe handoff, and restart-from-repo workflows.
+
+### Phase 2: Public GitHub Surface
+
+- We rewrote the README so it could work as a real public landing page instead of an internal operator notebook.
+- We added diagrams, docs, examples, launch materials, and competitive framing.
+- We removed internal-only wording and draft-only critique sections that were useful during design but wrong for the public README.
+
+### Phase 3: Adapter Foundation
+
+- We introduced explicit platform adapters and support tiers instead of pretending every tool has the same lifecycle primitives.
+- We created a platform matrix backed by tests so the docs could not drift too far from the implementation.
+- We opened follow-up issues for unsupported or partially-supported ecosystems instead of inflating the support story.
+
+### Phase 4: Platform Expansion
+
+- We implemented credible partial support for Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi.
+- For hybrid/manual platforms, we kept the support boundary honest:
+  - Lovable uses exported repo knowledge plus manual UI knowledge steps
+  - OpenClaw uses workspace files but still requires manual runtime configuration
+  - Ollama support is Modelfile/template support, not full repo-aware agent-runtime support
+  - Kimi support is scoped to Kimi Code CLI project context
+
+### Phase 5: Canonical Repo Memory Contract
+
+- We promoted `specs/README.md` and `UBIQUITOUS_LANGUAGE.md` into tracked canonical files on `main`.
+- We reduced the noisy memory-sync behavior so branch-specific churn stopped polluting the top-level memory block.
+- This made the repo contract inherit cleanly across future worktrees.
+
+### Phase 6: Repo-First Onboarding
+
+- We added:
+  - `repo-context-hooks init`
+  - repo-wide `repo-context-hooks doctor`
+- This aligned the CLI with the product story:
+  - establish repo contract first
+  - validate repo contract
+  - then install platform-specific continuity surfaces
+
+### Phase 7: Platform Readiness
+
+- We designed and implemented the next operator layer:
+  - `repo-context-hooks doctor --all-platforms`
+  - `repo-context-hooks recommend`
+- This phase reduces guesswork after onboarding by showing support-wide readiness and transparent next-step recommendations.
+- The implementation is complete in the active feature branch and verified locally.
 
 ## Design Decisions
 
@@ -37,24 +117,64 @@ This file is the persistent project context for agents and maintainers.
 - Keep the public README outcome-focused and move operator-heavy details into docs and playbooks.
 - Model platform support with explicit tiers (`native`, `partial`, `planned`) instead of broad compatibility claims.
 - Track compatibility aliases (`repo-context-hooks`, `repohandoff`, `graphify`) while keeping the product language centered on `repo-context-hooks`.
+- Treat the repo contract as the durable continuity boundary:
+  - `README.md` for user-facing understanding
+  - `specs/README.md` for engineering memory
+  - `UBIQUITOUS_LANGUAGE.md` for shared terminology
+- Keep verification and advice separate:
+  - `doctor` verifies actual state
+  - `recommend` explains the best next move
+- Keep partial platforms useful without pretending they expose Claude-style hook parity.
 
 ## What Worked
 
 - Tight claim boundaries improved trust: each platform is documented according to its real integration surface.
 - Platform-specific adapters plus playbooks made the product more useful without pretending every tool has Claude-style hooks.
 - Contract tests on README, docs, templates, and visuals helped keep product positioning and implementation in sync.
+- Repo-first onboarding made the product easier to understand and made the CLI match the product promise.
+- Canonical tracked memory files reduced repeated worktree clutter and made context continuity feel intentional.
+- Product-driven development with real issues, PRs, releases, and checkpoints created a stronger public artifact than one large undocumented push would have.
 
 ## What Failed or Was Reverted
 
 - Overly internal README sections hurt the public GitHub landing page and had to be removed.
-- Broad “all agents” wording created avoidable trust gaps because the runtime support was narrower than the marketing language.
+- Broad "all agents" wording created avoidable trust gaps because the runtime support was narrower than the marketing language.
 - Leaving repo memory files untracked caused repeated worktree noise and made the contract feel optional instead of canonical.
+- Early diagrams were too generic and had to be improved because they explained the mechanism without showing enough real product value.
+- Some verification paths exposed environment-specific issues that should be tracked separately instead of patched blindly inside feature branches.
+- Editable-install verification on Windows/Conda exposed a console-launcher quirk that is now tracked as follow-up work instead of being buried.
+
+## Releases, PRs, and Current State
+
+- `main` currently includes:
+  - platform foundation
+  - platform polish
+  - canonical repo memory contract
+  - repo-first onboarding
+  - release `v0.2.1`
+- Active feature branch:
+  - `feat/platform-readiness`
+- Active PR:
+  - adds `doctor --all-platforms`
+  - adds `recommend`
+  - updates docs to explain readiness vs recommendations
+- Active follow-up issue:
+  - Windows editable launcher behavior discovered during verification and tracked separately from feature logic
+- Expected path from here:
+  - update memory
+  - merge readiness PR
+  - cut next release
+  - start the next product phase from fresh `origin/main`
 
 ## Open Issues and Next Work
 
 - Keep the repo memory contract canonical and low-noise so future worktrees stop accumulating untracked bootstrap files.
 - Continue raising platform quality through real support surfaces, not expanded marketing copy.
 - Improve launch assets and public examples only when they stay faithful to the implementation boundary.
+- Merge the platform-readiness branch after final review.
+- Cut the next release so readiness and recommendation commands become part of the published package.
+- Resolve the Windows editable-launcher issue separately, because it affects verification confidence on Windows even though feature logic is passing.
+- Start the next product phase from fresh `main` rather than stacking more work on an aging branch.
 
 ## How To Work in This Repo
 
@@ -66,3 +186,17 @@ This file is the persistent project context for agents and maintainers.
 
 ## Session Checkpoints
 
+### Current Checkpoint
+
+- This file now captures the project history through the platform-readiness phase.
+- Active branch:
+  - `feat/platform-readiness`
+- Branch purpose:
+  - add `doctor --all-platforms`
+  - add `recommend`
+  - document the new repo-first readiness flow
+- Verification completed for the active branch:
+  - full test suite passing locally
+  - repo-first command flow smoke-tested
+- Known follow-up:
+  - Windows editable console-launcher behavior is tracked separately and should not be conflated with the readiness feature itself

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
-from repo_context_hooks.cli import _doctor, _init, _install, _platforms, build_parser
+from repo_context_hooks.cli import _doctor, _init, _install, _platforms, _recommend, build_parser
 from repo_context_hooks.doctor import DoctorReport
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,8 +30,10 @@ def test_parser_supports_platforms_and_doctor_commands() -> None:
 
     assert parser.parse_args(["platforms"]).command == "platforms"
     assert parser.parse_args(["doctor", "--platform", "claude"]).command == "doctor"
+    assert parser.parse_args(["doctor", "--all-platforms"]).command == "doctor"
     assert parser.parse_args(["doctor"]).command == "doctor"
     assert parser.parse_args(["init"]).command == "init"
+    assert parser.parse_args(["recommend"]).command == "recommend"
 
 
 def test_platforms_print_support_tiers(capsys) -> None:
@@ -166,6 +168,35 @@ def test_doctor_returns_nonzero_for_missing_state(
     assert "repo-context-continuity.mdc" in out
 
 
+def test_doctor_all_platforms_prints_matrix_summary(
+    monkeypatch,
+    capsys,
+) -> None:
+    tmp_path = _tmp_dir()
+
+    class FakeReport:
+        ok = True
+
+        def render(self) -> str:
+            return "[OK] platform-readiness\nclaude\tnative\tmissing\tsettings.json"
+
+    monkeypatch.setattr(
+        "repo_context_hooks.cli.diagnose_all_platforms",
+        lambda repo_root: FakeReport(),
+    )
+
+    args = Namespace(
+        platform=None,
+        all_platforms=True,
+        repo_root=str(tmp_path),
+    )
+
+    assert _doctor(args) == 0
+    out = capsys.readouterr().out
+    assert "platform-readiness" in out
+    assert "claude" in out
+
+
 def test_init_prints_repo_contract_statuses(
     monkeypatch,
     capsys,
@@ -195,3 +226,29 @@ def test_init_prints_repo_contract_statuses(
     assert "Initialized repo contract" in out
     assert "README.md: installed" in out
     assert "AGENTS.md: skipped" in out
+
+
+def test_recommend_prints_ranked_output(
+    monkeypatch,
+    capsys,
+) -> None:
+    tmp_path = _tmp_dir()
+
+    class FakeRecommendations:
+        def render(self) -> str:
+            return "[RECOMMEND]\n1. claude\nNext: repo-context-hooks install --platform claude"
+
+    monkeypatch.setattr(
+        "repo_context_hooks.cli.recommend_setup",
+        lambda repo_root, limit=3: FakeRecommendations(),
+    )
+
+    args = Namespace(
+        repo_root=str(tmp_path),
+        limit=3,
+    )
+
+    assert _recommend(args) == 0
+    out = capsys.readouterr().out
+    assert "[RECOMMEND]" in out
+    assert "repo-context-hooks install --platform claude" in out

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import uuid4
 
-from repo_context_hooks.doctor import diagnose_platform, diagnose_repo_contract
+from repo_context_hooks.doctor import diagnose_all_platforms, diagnose_platform, diagnose_repo_contract
 from repo_context_hooks.installer import install_platform
 from repo_context_hooks.repo_contract import init_repo_contract
 
@@ -66,6 +66,50 @@ def test_repo_doctor_rejects_placeholder_specs_readme() -> None:
     assert report.ok is False
     assert "specs/README.md" in report.invalid
     assert "INVALID" in report.render()
+
+
+def test_all_platforms_doctor_is_nonfatal_for_missing_platform_setup() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+
+    report = diagnose_all_platforms(repo, home=tmp_path / "home")
+
+    assert report.ok is True
+    rendered = report.render()
+    assert "[OK] platform-readiness" in rendered
+    assert "repo-contract\tok" in rendered
+    assert "claude\tnative\tmissing" in rendered
+
+
+def test_all_platforms_doctor_fails_on_invalid_platform_state() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    _write_repo_contract(repo)
+
+    install_platform("replit", repo_root=repo, home=tmp_path / "home")
+    (repo / "replit.md").write_text("placeholder\n", encoding="utf-8")
+
+    report = diagnose_all_platforms(repo, home=tmp_path / "home")
+
+    assert report.ok is False
+    assert "replit\tpartial\tinvalid" in report.render()
+
+
+def test_all_platforms_doctor_renders_compact_relative_details() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+
+    report = diagnose_all_platforms(repo, home=tmp_path / "home")
+
+    rendered = report.render()
+    assert "home:.claude/skills/context-handoff-hooks" in rendered
+    assert "repo:.cursor/rules/repo-context-continuity.mdc" in rendered
 
 
 def test_doctor_reports_missing_cursor_rule() -> None:

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from repo_context_hooks.recommend import recommend_setup
+from repo_context_hooks.repo_contract import init_repo_contract
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _tmp_dir() -> Path:
+    base = ROOT / ".tmp-tests"
+    base.mkdir(exist_ok=True)
+    path = base / uuid4().hex
+    path.mkdir()
+    return path
+
+
+def test_recommend_prefers_init_when_repo_contract_is_missing() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    report = recommend_setup(repo)
+
+    rendered = report.render()
+    assert "repo-context-hooks init" in rendered
+    assert "repo-context-hooks doctor" in rendered
+
+
+def test_recommend_defaults_to_claude_for_repo_contract_only_repo() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+
+    report = recommend_setup(repo)
+
+    rendered = report.render()
+    assert "1. claude" in rendered.lower()
+    assert "repo-context-hooks install --platform claude" in rendered
+
+
+def test_recommend_prefers_explicit_platform_signal() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+    (repo / "replit.md").write_text("# Replit\n", encoding="utf-8")
+
+    report = recommend_setup(repo)
+
+    rendered = report.render().lower()
+    assert "1. replit" in rendered
+    assert "detected repo signal" in rendered


### PR DESCRIPTION
## Summary
- add doctor --all-platforms for repo contract plus platform readiness checks
- add ecommend to rank next setup paths from visible repo signals
- document the new repo-first readiness flow and record the design/plan artifacts

## Verification
- python -m pytest -q --basetemp .pytest-tmp-platform-readiness
- smoke-tested init, doctor, doctor --all-platforms, and ecommend through the CLI entrypoint logic in a temp repo

## Notes
- while verifying, the generated Windows console launcher from editable install failed in this local Conda environment with ModuleNotFoundError; the feature logic itself passed through tests and direct main() invocation, so I kept that launcher quirk out of scope for this branch rather than guessing at a packaging fix
