### PR TITLE
feat: add JSON output and clarify README install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,15 @@ Repo-native continuity for coding agents.
 
 ```bash
 python -m pip install -e .
+```
+
+Start in any repository:
+
+```bash
 repo-context-hooks init
 repo-context-hooks doctor
 repo-context-hooks doctor --all-platforms
 repo-context-hooks recommend
-repo-context-hooks install --platform claude
-repo-context-hooks install --platform codex
-repo-context-hooks install --platform replit
-repo-context-hooks install --platform windsurf
-repo-context-hooks install --platform lovable
-repo-context-hooks install --platform openclaw
-repo-context-hooks install --platform ollama
-repo-context-hooks install --platform kimi
 ```
 
 Current support is intentionally narrow: Claude is the native path, while Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi are useful but partial integrations.
@@ -28,9 +25,67 @@ The first-run path is now repo-first:
 2. `repo-context-hooks doctor`
 3. `repo-context-hooks doctor --all-platforms`
 4. `repo-context-hooks recommend`
-5. `repo-context-hooks install --platform <name>`
+5. `repo-context-hooks install --platform <platform>`
 
 `doctor` answers "is the repo contract healthy?" `doctor --all-platforms` answers "which supported platforms are actually ready?" `recommend` answers "what should I do next in this repo?"
+
+## Pick Your Platform
+
+Run one platform install command after the repo contract is healthy.
+
+Claude:
+
+```bash
+repo-context-hooks install --platform claude
+```
+
+Cursor:
+
+```bash
+repo-context-hooks install --platform cursor
+```
+
+Codex:
+
+```bash
+repo-context-hooks install --platform codex
+```
+
+Replit:
+
+```bash
+repo-context-hooks install --platform replit
+```
+
+Windsurf:
+
+```bash
+repo-context-hooks install --platform windsurf
+```
+
+Lovable:
+
+```bash
+repo-context-hooks install --platform lovable
+```
+
+OpenClaw:
+
+```bash
+repo-context-hooks install --platform openclaw
+```
+
+Ollama:
+
+```bash
+repo-context-hooks install --platform ollama
+```
+
+Kimi:
+
+```bash
+repo-context-hooks install --platform kimi
+```
 
 ## Why Repo-Native Continuity
 
@@ -80,8 +135,6 @@ The support tiers are `native`, `partial`, and `planned`.
 
 See [docs/platforms.md](docs/platforms.md) for the support matrix, platform-specific caveats, and the current claim boundary. The short version is that we do not claim universal agent support, and we do not claim hook parity or compact automation for Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, or Kimi.
 
-For exact post-install steps on each partial platform, see [docs/platform-playbooks.md](docs/platform-playbooks.md).
-
 ## Readiness And Recommendations
 
 Use the new repo-first commands together:
@@ -95,6 +148,15 @@ repo-context-hooks recommend
 - `recommend` ranks the best next setup paths for the current repo, prints the repo signals it used, and gives the exact next install command to run.
 
 That combination keeps the product honest: readiness is verification, recommendation is advice, and neither widens the public support claim.
+
+For scripts, CI, and agent wrappers, add `--json`:
+
+```bash
+repo-context-hooks platforms --json
+repo-context-hooks doctor --json
+repo-context-hooks doctor --all-platforms --json
+repo-context-hooks recommend --json
+```
 
 ## Concrete Stories
 
@@ -117,11 +179,8 @@ Without a checked-in continuity contract, teams repeat themselves. With one, the
 - [Platform support](docs/platforms.md)
 - [Engineering memory](specs/README.md)
 - [Ubiquitous language](UBIQUITOUS_LANGUAGE.md)
-- [Platform playbooks](docs/platform-playbooks.md)
 - [Architecture](docs/architecture.md)
 - [Competitive analysis](docs/competitive-analysis.md)
-- [Planned platform roadmap](docs/launch/platform-roadmap.md)
-- [Animation plan](docs/demo/animation-plan.md)
 - [Minimal repo example](examples/minimal-repo/)
 - [Multi-project example](examples/multi-project/)
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -29,8 +29,6 @@ Use the matrix above as the public boundary for support claims:
 - do not describe planned platforms as implemented
 - do not claim native lifecycle hooks or compact automation on partial platforms unless the platform actually exposes them
 
-For step-by-step post-install guidance, use [docs/platform-playbooks.md](platform-playbooks.md).
-
 ## Readiness Commands
 
 Use the platform support matrix with the new CLI surface:
@@ -47,6 +45,14 @@ These commands are complementary:
 
 - use `doctor --all-platforms` when you want a support-wide verification snapshot
 - use `recommend` when you want the shortest credible next step for the current repo
+
+For structured consumers:
+
+```bash
+repo-context-hooks platforms --json
+repo-context-hooks doctor --all-platforms --json
+repo-context-hooks recommend --json
+```
 
 ## How To Read The Matrix
 

--- a/docs/superpowers/plans/2026-04-24-readme-json-output-implementation.md
+++ b/docs/superpowers/plans/2026-04-24-readme-json-output-implementation.md
@@ -1,0 +1,31 @@
+# README Install Flow and JSON Output Implementation Plan
+
+**Goal:** Improve the public README adoption path and add machine-readable output for the commands agents and scripts are most likely to consume.
+
+## Task 1: Lock README and JSON expectations with tests
+
+- Update README contract tests so the README requires separate platform install snippets.
+- Add tests that keep internal-heavy docs out of the README primary link path.
+- Add CLI/parser tests for `--json`.
+- Add model tests for report `to_dict()` methods.
+
+## Task 2: Add JSON serialization
+
+- Add `to_dict()` methods to doctor reports.
+- Add `to_dict()` methods to recommendation reports.
+- Add JSON rendering support in the CLI.
+- Add `--json` to `platforms`, `doctor`, and `recommend`.
+
+## Task 3: Rewrite README and supporting docs
+
+- Split install/setup into smaller copyable blocks.
+- Add a `Pick Your Platform` section.
+- Remove platform playbook links from the public README path.
+- Keep support matrix docs focused on claims and readiness.
+
+## Task 4: Verify and publish
+
+- Run focused tests.
+- Run the full test suite.
+- Smoke-test representative JSON commands.
+- Commit, push, and open a PR.

--- a/docs/superpowers/specs/2026-04-24-readme-json-output-design.md
+++ b/docs/superpowers/specs/2026-04-24-readme-json-output-design.md
@@ -1,0 +1,49 @@
+# README Install Flow and JSON Output Design
+
+## Problem
+
+The README made the platform install step look like a sequence of commands to run all at once. That is not how users adopt the tool: they initialize the repo once, inspect readiness, then choose the one platform they actually use.
+
+The public README also linked directly to deeper operator docs such as platform playbooks. Those docs can remain useful for maintainers, but they should not be part of the first GitHub landing path.
+
+Finally, the new readiness commands are still human-readable only. Agent wrappers, CI jobs, and shell scripts need structured output if this project is going to be useful as a building block.
+
+## Goals
+
+- Make the README onboarding path easy to scan and copy.
+- Split platform install commands by platform.
+- Remove internal-heavy docs from the README primary link path.
+- Add `--json` output for:
+  - `platforms`
+  - `doctor`
+  - `doctor --all-platforms`
+  - `recommend`
+
+## Non-Goals
+
+- Add new platform adapters.
+- Change support tiers.
+- Remove maintainer docs from the repository.
+- Add JSON output to `install` in this phase.
+
+## Design
+
+The README should show the workflow as:
+
+1. install the package
+2. initialize the repo contract
+3. run doctor/readiness/recommendation checks
+4. choose one platform-specific install command
+
+The CLI should keep human-readable output as the default and add `--json` as an opt-in flag. The JSON contract should use stable field names based on the existing model objects:
+
+- `DoctorReport.to_dict()`
+- `AllPlatformsReport.to_dict()`
+- `RecommendationReport.to_dict()`
+- platform registry metadata for `platforms --json`
+
+## Self-Critique
+
+This is intentionally a small JSON contract. It does not try to become a full schema registry yet. That keeps the change easy to review and avoids prematurely freezing fields that future users may not need.
+
+The README still links to `docs/platforms.md`, which is public and detailed. That is appropriate because support claims should stay easy to audit. The deeper playbook and positioning docs should not be pushed from the landing page.

--- a/repo_context_hooks/cli.py
+++ b/repo_context_hooks/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 from .doctor import diagnose_all_platforms, diagnose_platform
@@ -79,6 +80,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=".",
         help="Repository root to inspect (default: current directory).",
     )
+    doctor.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON output.",
+    )
 
     recommend = subparsers.add_parser(
         "recommend",
@@ -95,15 +101,46 @@ def build_parser() -> argparse.ArgumentParser:
         default=3,
         help="Maximum number of platform recommendations to print (default: 3).",
     )
+    recommend.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON output.",
+    )
 
-    subparsers.add_parser(
+    platforms = subparsers.add_parser(
         "platforms",
         help="List supported platforms and support tiers.",
+    )
+    platforms.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON output.",
     )
     return parser
 
 
-def _platforms() -> int:
+def _print_json(payload: object) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _platforms(args: argparse.Namespace | None = None) -> int:
+    if getattr(args, "json", False):
+        _print_json(
+            {
+                "platforms": [
+                    {
+                        "id": adapter.metadata.id,
+                        "display_name": adapter.metadata.display_name,
+                        "support_tier": adapter.metadata.support_tier.value,
+                        "install_surfaces": list(adapter.metadata.install_surfaces),
+                        "summary": adapter.metadata.summary,
+                    }
+                    for adapter in get_registry().all()
+                ]
+            }
+        )
+        return 0
+
     for adapter in get_registry().all():
         meta = adapter.metadata
         surfaces = ", ".join(meta.install_surfaces)
@@ -168,14 +205,20 @@ def _doctor(args: argparse.Namespace) -> int:
         )
     else:
         report = diagnose_repo_contract(repo_root)
-    print(report.render())
+    if getattr(args, "json", False):
+        _print_json(report.to_dict())
+    else:
+        print(report.render())
     return 0 if report.ok else 1
 
 
 def _recommend(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
     report = recommend_setup(repo_root=repo_root, limit=args.limit)
-    print(report.render())
+    if getattr(args, "json", False):
+        _print_json(report.to_dict())
+    else:
+        print(report.render())
     return 0
 
 
@@ -187,7 +230,7 @@ def main() -> int:
     if args.command == "install":
         return _install(args)
     if args.command == "platforms":
-        return _platforms()
+        return _platforms(args)
     if args.command == "doctor":
         return _doctor(args)
     if args.command == "recommend":

--- a/repo_context_hooks/doctor.py
+++ b/repo_context_hooks/doctor.py
@@ -29,6 +29,23 @@ class DoctorReport:
         lines.extend(f"warning: {item}" for item in self.warnings)
         return "\n".join(lines)
 
+    def to_dict(self) -> dict[str, object]:
+        if self.ok:
+            status = "ok"
+        elif self.invalid:
+            status = "invalid"
+        else:
+            status = "missing"
+        return {
+            "platform_id": self.platform_id,
+            "ok": self.ok,
+            "status": status,
+            "present": list(self.present),
+            "missing": list(self.missing),
+            "invalid": list(self.invalid),
+            "warnings": list(self.warnings),
+        }
+
 
 @dataclass(frozen=True)
 class PlatformReadinessRow:
@@ -68,6 +85,15 @@ class PlatformReadinessRow:
             warnings=report.warnings,
         )
 
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "platform_id": self.platform_id,
+            "support_tier": self.support_tier,
+            "state": self.state,
+            "detail": self.detail,
+            "warnings": list(self.warnings),
+        }
+
 
 @dataclass(frozen=True)
 class AllPlatformsReport:
@@ -100,6 +126,13 @@ class AllPlatformsReport:
             for warning in row.warnings
         )
         return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "repo_contract": self.repo_contract.to_dict(),
+            "platforms": [row.to_dict() for row in self.rows],
+        }
 
 
 def _compact_detail(item: str, repo_root: Path, home: Path | None = None) -> str:

--- a/repo_context_hooks/recommend.py
+++ b/repo_context_hooks/recommend.py
@@ -15,6 +15,15 @@ class Recommendation:
     signals: tuple[str, ...]
     next_command: str
 
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "platform_id": self.platform_id,
+            "score": self.score,
+            "reasons": list(self.reasons),
+            "signals": list(self.signals),
+            "next_command": self.next_command,
+        }
+
 
 @dataclass(frozen=True)
 class RecommendationReport:
@@ -48,6 +57,18 @@ class RecommendationReport:
                 lines.append(f"   Why: {reason}")
             lines.append(f"   Next: {recommendation.next_command}")
         return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "repo_contract_ok": self.repo_contract_ok,
+            "repo_contract_detail": self.repo_contract_detail,
+            "detected_signals": list(self.detected_signals),
+            "preflight_commands": list(self.preflight_commands),
+            "recommendations": [
+                recommendation.to_dict()
+                for recommendation in self.recommendations
+            ],
+        }
 
 
 _BASE_SCORES = {

--- a/specs/README.md
+++ b/specs/README.md
@@ -188,15 +188,14 @@ This file is the persistent project context for agents and maintainers.
 
 ### Current Checkpoint
 
-- This file now captures the project history through the platform-readiness phase.
+- This file captures the project history through the platform-readiness phase and the next public README/JSON-output phase.
 - Active branch:
-  - `feat/platform-readiness`
+  - `feat/readme-json-output`
 - Branch purpose:
-  - add `doctor --all-platforms`
-  - add `recommend`
-  - document the new repo-first readiness flow
-- Verification completed for the active branch:
-  - full test suite passing locally
-  - repo-first command flow smoke-tested
+  - make README install commands easier to choose per platform
+  - remove internal-heavy docs from the README primary path
+  - add `--json` output for readiness, recommendation, and platform listing commands
+- Verification completed so far:
+  - focused README/CLI/doctor/recommend tests passing locally
 - Known follow-up:
-  - Windows editable console-launcher behavior is tracked separately and should not be conflated with the readiness feature itself
+  - decide later whether `install` also needs JSON output after real wrapper users ask for it

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
@@ -29,15 +30,18 @@ def test_parser_supports_platforms_and_doctor_commands() -> None:
     parser = build_parser()
 
     assert parser.parse_args(["platforms"]).command == "platforms"
+    assert parser.parse_args(["platforms", "--json"]).json is True
     assert parser.parse_args(["doctor", "--platform", "claude"]).command == "doctor"
+    assert parser.parse_args(["doctor", "--platform", "claude", "--json"]).json is True
     assert parser.parse_args(["doctor", "--all-platforms"]).command == "doctor"
     assert parser.parse_args(["doctor"]).command == "doctor"
     assert parser.parse_args(["init"]).command == "init"
     assert parser.parse_args(["recommend"]).command == "recommend"
+    assert parser.parse_args(["recommend", "--json"]).json is True
 
 
 def test_platforms_print_support_tiers(capsys) -> None:
-    assert _platforms() == 0
+    assert _platforms(Namespace(json=False)) == 0
 
     out = capsys.readouterr().out
     assert "claude" in out
@@ -51,6 +55,14 @@ def test_platforms_print_support_tiers(capsys) -> None:
     assert "kimi" in out
     assert "native" in out
     assert "partial" in out
+
+
+def test_platforms_prints_json(capsys) -> None:
+    assert _platforms(Namespace(json=True)) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["platforms"][0]["id"] == "claude"
+    assert payload["platforms"][0]["support_tier"] == "native"
 
 
 def test_install_skips_repo_context_outside_git_repo(
@@ -180,6 +192,9 @@ def test_doctor_all_platforms_prints_matrix_summary(
         def render(self) -> str:
             return "[OK] platform-readiness\nclaude\tnative\tmissing\tsettings.json"
 
+        def to_dict(self):
+            return {"ok": True, "platforms": [{"platform_id": "claude"}]}
+
     monkeypatch.setattr(
         "repo_context_hooks.cli.diagnose_all_platforms",
         lambda repo_root: FakeReport(),
@@ -189,12 +204,44 @@ def test_doctor_all_platforms_prints_matrix_summary(
         platform=None,
         all_platforms=True,
         repo_root=str(tmp_path),
+        json=False,
     )
 
     assert _doctor(args) == 0
     out = capsys.readouterr().out
     assert "platform-readiness" in out
     assert "claude" in out
+
+
+def test_doctor_prints_json(
+    monkeypatch,
+    capsys,
+) -> None:
+    tmp_path = _tmp_dir()
+
+    class FakeReport:
+        ok = True
+
+        def render(self) -> str:
+            return "[OK] repo-contract"
+
+        def to_dict(self):
+            return {"platform_id": "repo-contract", "ok": True}
+
+    monkeypatch.setattr(
+        "repo_context_hooks.cli.diagnose_repo_contract",
+        lambda repo_root: FakeReport(),
+    )
+
+    args = Namespace(
+        platform=None,
+        all_platforms=False,
+        repo_root=str(tmp_path),
+        json=True,
+    )
+
+    assert _doctor(args) == 0
+    assert json.loads(capsys.readouterr().out)["platform_id"] == "repo-contract"
 
 
 def test_init_prints_repo_contract_statuses(
@@ -238,6 +285,9 @@ def test_recommend_prints_ranked_output(
         def render(self) -> str:
             return "[RECOMMEND]\n1. claude\nNext: repo-context-hooks install --platform claude"
 
+        def to_dict(self):
+            return {"recommendations": [{"platform_id": "claude"}]}
+
     monkeypatch.setattr(
         "repo_context_hooks.cli.recommend_setup",
         lambda repo_root, limit=3: FakeRecommendations(),
@@ -246,9 +296,39 @@ def test_recommend_prints_ranked_output(
     args = Namespace(
         repo_root=str(tmp_path),
         limit=3,
+        json=False,
     )
 
     assert _recommend(args) == 0
     out = capsys.readouterr().out
     assert "[RECOMMEND]" in out
     assert "repo-context-hooks install --platform claude" in out
+
+
+def test_recommend_prints_json(
+    monkeypatch,
+    capsys,
+) -> None:
+    tmp_path = _tmp_dir()
+
+    class FakeRecommendations:
+        def render(self) -> str:
+            return "[RECOMMEND]"
+
+        def to_dict(self):
+            return {"recommendations": [{"platform_id": "claude"}]}
+
+    monkeypatch.setattr(
+        "repo_context_hooks.cli.recommend_setup",
+        lambda repo_root, limit=3: FakeRecommendations(),
+    )
+
+    args = Namespace(
+        repo_root=str(tmp_path),
+        limit=3,
+        json=True,
+    )
+
+    assert _recommend(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["recommendations"][0]["platform_id"] == "claude"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -54,6 +54,19 @@ def test_repo_doctor_reports_initialized_contract() -> None:
     assert "AGENTS.md" in report.present
 
 
+def test_repo_doctor_exposes_json_contract() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+
+    payload = diagnose_repo_contract(repo).to_dict()
+
+    assert payload["platform_id"] == "repo-contract"
+    assert payload["status"] == "ok"
+    assert "README.md" in payload["present"]
+
+
 def test_repo_doctor_rejects_placeholder_specs_readme() -> None:
     tmp_path = _tmp_dir()
     repo = tmp_path / "repo"
@@ -110,6 +123,20 @@ def test_all_platforms_doctor_renders_compact_relative_details() -> None:
     rendered = report.render()
     assert "home:.claude/skills/context-handoff-hooks" in rendered
     assert "repo:.cursor/rules/repo-context-continuity.mdc" in rendered
+
+
+def test_all_platforms_doctor_exposes_json_contract() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+
+    payload = diagnose_all_platforms(repo, home=tmp_path / "home").to_dict()
+
+    assert payload["ok"] is True
+    assert payload["repo_contract"]["platform_id"] == "repo-contract"
+    assert payload["platforms"][0]["platform_id"] == "claude"
+    assert payload["platforms"][0]["support_tier"] == "native"
 
 
 def test_doctor_reports_missing_cursor_rule() -> None:

--- a/tests/test_platform_playbooks.py
+++ b/tests/test_platform_playbooks.py
@@ -6,14 +6,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_platform_playbooks_doc_exists_and_is_linked() -> None:
+def test_platform_playbooks_doc_exists_but_is_not_primary_public_path() -> None:
     playbooks = ROOT / "docs" / "platform-playbooks.md"
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     platforms = (ROOT / "docs" / "platforms.md").read_text(encoding="utf-8")
 
     assert playbooks.exists()
-    assert "docs/platform-playbooks.md" in readme
-    assert "docs/platform-playbooks.md" in platforms
+    assert "docs/platform-playbooks.md" not in readme
+    assert "docs/platform-playbooks.md" not in platforms
 
 
 def test_platform_playbooks_cover_supported_platforms_and_boundaries() -> None:

--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -83,7 +83,8 @@ def test_readme_promotes_repo_first_onboarding_sequence() -> None:
     expected_commands = [
         "repo-context-hooks init",
         "repo-context-hooks doctor",
-        "repo-context-hooks install --platform claude",
+        "repo-context-hooks recommend",
+        "repo-context-hooks install --platform <platform>",
     ]
     positions = []
     for command in expected_commands:
@@ -92,6 +93,30 @@ def test_readme_promotes_repo_first_onboarding_sequence() -> None:
         positions.append(position)
 
     assert positions == sorted(positions), "README onboarding commands are out of order"
+
+
+def test_readme_separates_platform_install_commands() -> None:
+    text = readme_text()
+    assert "## Pick Your Platform" in text
+    assert "Run one platform install command" in text
+    for platform in (
+        "claude",
+        "cursor",
+        "codex",
+        "replit",
+        "windsurf",
+        "lovable",
+        "openclaw",
+        "ollama",
+        "kimi",
+    ):
+        assert f"repo-context-hooks install --platform {platform}" in text
+
+
+def test_readme_keeps_internal_docs_out_of_primary_links() -> None:
+    text = readme_text()
+    assert "docs/platform-playbooks.md" not in text
+    assert "docs/positioning.md" not in text
 
 
 def test_readme_avoids_internal_operator_heavy_sections() -> None:
@@ -123,8 +148,6 @@ def test_readme_links_supporting_docs_and_examples() -> None:
     expected_links = [
         ("docs/architecture.md", ROOT / "docs" / "architecture.md"),
         ("docs/competitive-analysis.md", ROOT / "docs" / "competitive-analysis.md"),
-        ("docs/demo/animation-plan.md", ROOT / "docs" / "demo" / "animation-plan.md"),
-        ("docs/launch/platform-roadmap.md", ROOT / "docs" / "launch" / "platform-roadmap.md"),
         ("examples/minimal-repo/", ROOT / "examples" / "minimal-repo"),
         ("examples/multi-project/", ROOT / "examples" / "multi-project"),
     ]

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -43,6 +43,21 @@ def test_recommend_defaults_to_claude_for_repo_contract_only_repo() -> None:
     assert "repo-context-hooks install --platform claude" in rendered
 
 
+def test_recommend_exposes_json_contract() -> None:
+    tmp_path = _tmp_dir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+
+    payload = recommend_setup(repo).to_dict()
+
+    assert payload["repo_contract_ok"] is True
+    assert payload["recommendations"][0]["platform_id"] == "claude"
+    assert payload["recommendations"][0]["next_command"] == (
+        "repo-context-hooks install --platform claude --repo-root ."
+    )
+
+
 def test_recommend_prefers_explicit_platform_signal() -> None:
     tmp_path = _tmp_dir()
     repo = tmp_path / "repo"


### PR DESCRIPTION
## Summary
- split README setup from per-platform install commands so users can copy the one command they need
- remove platform playbooks from the README/platform-doc primary public path
- add --json output for platforms, doctor, doctor --all-platforms, and ecommend
- record the design and implementation plan for this phase

## Verification
- python -m pytest -q tests/test_readme_contract.py tests/test_cli.py tests/test_doctor.py tests/test_recommend.py --basetemp .pytest-tmp-json-focused
- python -m pytest -q --basetemp .pytest-tmp-readme-json-full
- python -m pip install -e .
- epo-context-hooks platforms --json
- epo-context-hooks doctor --json
- epo-context-hooks doctor --all-platforms --json
- epo-context-hooks recommend --json

Closes #18
