### PR TITLE
fix: sampling gate + session duration + ROI metrics dashboard

### DIFF
--- a/docs/monitoring/history.json
+++ b/docs/monitoring/history.json
@@ -21,7 +21,7 @@
   "observed_events": 26,
   "repo": "repo-context-hooks",
   "score": 90,
-  "snapshot_at": "2026-04-28T01:57:11Z",
+  "snapshot_at": "2026-04-28T01:59:06Z",
   "time_series": [
     {
       "date": "2026-04-27",
@@ -37,7 +37,7 @@
     "cold_start_time_saved_minutes": 0,
     "lifecycle_coverage": 25,
     "max_session_duration_minutes": null,
-    "readiness_minutes_since_last_event": 205,
+    "readiness_minutes_since_last_event": 207,
     "reload_events": 0,
     "resume_events": 26,
     "score_week1_uplift": null,

--- a/docs/monitoring/history.json
+++ b/docs/monitoring/history.json
@@ -1,49 +1,46 @@
 {
   "baseline": 20,
   "event_counts": {
-    "session-start": 91
+    "session-start": 26
   },
-  "first_seen": "2026-04-26T19:57:31.854624+00:00",
+  "first_seen": "2026-04-27T21:09:50.757559+00:00",
   "forecast": {
     "confidence": "low",
-    "daily_rate": 45.5,
+    "daily_rate": 26.0,
     "projected_active_days": 30,
-    "projected_events": 1365,
+    "projected_events": 780,
     "week_series": [
-      318,
-      318,
-      318,
-      318,
-      91
+      182,
+      182,
+      182,
+      182,
+      52
     ]
   },
-  "latest_seen": "2026-04-27T20:23:22.081254+00:00",
-  "observed_events": 91,
+  "latest_seen": "2026-04-27T22:32:19.320459+00:00",
+  "observed_events": 26,
   "repo": "repo-context-hooks",
   "score": 90,
-  "snapshot_at": "2026-04-27T20:23:31Z",
+  "snapshot_at": "2026-04-28T01:57:11Z",
   "time_series": [
     {
-      "date": "2026-04-26",
-      "events": 13,
-      "score": 90
-    },
-    {
       "date": "2026-04-27",
-      "events": 78,
+      "events": 26,
       "score": 90
     }
   ],
   "uplift": 70,
   "usability": {
-    "active_days": 2,
+    "active_days": 1,
     "avg_session_duration_minutes": null,
     "checkpoint_events": 0,
+    "cold_start_time_saved_minutes": 0,
     "lifecycle_coverage": 25,
     "max_session_duration_minutes": null,
-    "readiness_minutes_since_last_event": 0,
+    "readiness_minutes_since_last_event": 205,
     "reload_events": 0,
-    "resume_events": 91,
+    "resume_events": 26,
+    "score_week1_uplift": null,
     "session_end_events": 0
   }
 }

--- a/docs/monitoring/index.html
+++ b/docs/monitoring/index.html
@@ -168,25 +168,35 @@
         <div class="metric"><span>Contract score</span><strong>90</strong></div>
         <div class="metric"><span>Baseline (no hooks)</span><strong>20</strong></div>
         <div class="metric"><span>Continuity uplift</span><strong>+70</strong></div>
-        <div class="metric"><span>Hook events total</span><strong>91</strong></div>
+        <div class="metric"><span>Hook events total</span><strong>26</strong></div>
       </div>
 
       <!-- Context savings row -->
       <div class="savings-row">
         <div class="savings-card">
           <span>Tokens injected</span>
-          <strong>409,500</strong>
-          <em>~4,500 tok/session × 91 sessions</em>
+          <strong>117,000</strong>
+          <em>~4,500 tok/session × 26 sessions</em>
         </div>
         <div class="savings-card">
           <span>Tokens saved (est.)</span>
-          <strong>54,600</strong>
+          <strong>15,600</strong>
           <em>30% of sessions avoid 2,000-tok re-orientation</em>
         </div>
         <div class="savings-card">
           <span>Est. cost saved</span>
-          <strong>$0.16</strong>
+          <strong>$0.05</strong>
           <em>Claude Sonnet $3/M input tokens</em>
+        </div>
+        <div class="savings-card">
+          <span>Cold starts prevented (est.)</span>
+          <strong>—</strong>
+          <em>Each context reload saves ~5 min re-orientation</em>
+        </div>
+        <div class="savings-card">
+          <span>Week-1 uplift</span>
+          <strong>—</strong>
+          <em>Score gain from day 0 to day 7</em>
         </div>
       </div>
 
@@ -194,12 +204,11 @@
       <div class="grid">
         <section class="panel">
           <h2>Daily activity</h2>
-          <div class="bar-row"><span>2026-04-26</span><div class="bar-track"><div class="bar-fill" style="width:17%"></div></div><strong>13</strong></div>
-<div class="bar-row"><span>2026-04-27</span><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><strong>78</strong></div>
+          <div class="bar-row"><span>2026-04-27</span><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><strong>26</strong></div>
         </section>
         <section class="panel">
           <h2>Event mix</h2>
-          <div class="events"><div><span>session-start</span><strong>91</strong></div></div>
+          <div class="events"><div><span>session-start</span><strong>26</strong></div></div>
         </section>
       </div>
 
@@ -214,14 +223,13 @@
                 25% of the 4-event lifecycle is instrumented.
                 session-start is active. session-end, pre-compact, and post-compact will populate after longer sessions.
               </p>
-              <div class="lc-grid"><div class="lc-pill lc-active"><span>session-start</span><strong>91</strong></div><div class="lc-pill lc-empty"><span>pre-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>post-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>session-end</span><strong>0</strong></div></div>
+              <div class="lc-grid"><div class="lc-pill lc-active"><span>session-start</span><strong>26</strong></div><div class="lc-pill lc-empty"><span>pre-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>post-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>session-end</span><strong>0</strong></div></div>
             </div>
           </div>
         </section>
         <section class="panel">
           <h2>Score history</h2>
-          <div class="score-point"><span>2026-04-26</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
-<div class="score-point"><span>2026-04-27</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
+          <div class="score-point"><span>2026-04-27</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
         </section>
       </div>
 
@@ -241,8 +249,8 @@
         <section class="panel">
           <h2>Usability metrics</h2>
           <div class="usability">
-            <div><span>Active days</span><strong>2</strong></div>
-            <div><span>Sessions</span><strong>91</strong></div>
+            <div><span>Active days</span><strong>1</strong></div>
+            <div><span>Sessions</span><strong>26</strong></div>
             <div><span>Checkpoints</span><strong>0</strong></div>
             <div><span>Reloads</span><strong>0</strong></div>
             <div><span>Session ends</span><strong>0</strong></div>
@@ -257,11 +265,11 @@
         <section class="panel">
           <h2>30-day forecast <small style="font-size:14px;font-weight:400;opacity:.6">confidence: low</small></h2>
           <div class="metrics4">
-            <div class="metric"><span>Daily rate</span><strong>45.5</strong></div>
-            <div class="metric"><span>Projected events</span><strong>1,365</strong></div>
+            <div class="metric"><span>Daily rate</span><strong>26.0</strong></div>
+            <div class="metric"><span>Projected events</span><strong>780</strong></div>
             <div class="metric"><span>Active days (30d)</span><strong>30</strong></div>
           </div>
-          <div class="fc-grid"><div class="fc-week"><span>Week 1</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 2</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 3</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 4</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 5</span><strong>91</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div></div>
+          <div class="fc-grid"><div class="fc-week"><span>Week 1</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 2</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 3</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 4</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 5</span><strong>52</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div></div>
         </section>
         <section class="panel">
           <h2>Platform proof</h2>

--- a/repo_context_hooks/bundle/scripts/repo_specs_memory.py
+++ b/repo_context_hooks/bundle/scripts/repo_specs_memory.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
 
-EVENT = sys.argv[1] if len(sys.argv) > 1 else "session-start"
+_VALID_EVENTS = {"session-start", "pre-compact", "post-compact", "session-end"}
+_raw_env = os.environ.get("EVENT", "")
+EVENT: str = (
+    _raw_env if _raw_env in _VALID_EVENTS
+    else (sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] in _VALID_EVENTS else "session-start")
+)
 
 AUTO_BLOCK_START = "<!-- AUTO:REPO_CONTEXT_START -->"
 AUTO_BLOCK_END = "<!-- AUTO:REPO_CONTEXT_END -->"
@@ -205,13 +211,25 @@ def record_telemetry(repo_root: Path, specs_readme: Path, ul_path: Path) -> None
                 sys.path.insert(0, str(parent))
                 break
 
-        from repo_context_hooks.telemetry import record_event
+        from repo_context_hooks.telemetry import (
+            read_session_duration_minutes,
+            record_event,
+            record_session_start_time,
+        )
+
+        if EVENT == "session-start":
+            record_session_start_time(repo_root)
+
+        duration_minutes = (
+            read_session_duration_minutes(repo_root) if EVENT == "session-end" else None
+        )
 
         event_path = record_event(
             repo_root,
             EVENT,
             source="repo_specs_memory",
             details={"specs_readme": str(specs_readme), "glossary": str(ul_path)},
+            duration_minutes=duration_minutes,
         )
         print(f"- Telemetry: `{event_path}`")
     except Exception:

--- a/repo_context_hooks/bundle/skills/context-handoff-hooks/scripts/session_context.py
+++ b/repo_context_hooks/bundle/skills/context-handoff-hooks/scripts/session_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -8,7 +9,12 @@ import sys
 from pathlib import Path
 
 
-EVENT = sys.argv[1] if len(sys.argv) > 1 else "session-start"
+_VALID_EVENTS = {"session-start", "pre-compact", "post-compact", "session-end"}
+_raw_env = os.environ.get("EVENT", "")
+EVENT: str = (
+    _raw_env if _raw_env in _VALID_EVENTS
+    else (sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] in _VALID_EVENTS else "session-start")
+)
 
 
 def git_output(*args: str) -> str:
@@ -120,13 +126,22 @@ def record_telemetry(
             auto_commit_snapshot,
             clear_session_state,
             is_sampled,
+            read_session_duration_minutes,
             record_event,
+            record_session_start_time,
         )
 
         if not is_sampled(repo_root):
             if EVENT == "session-end":
                 clear_session_state(repo_root)
             return
+
+        if EVENT == "session-start":
+            record_session_start_time(repo_root)
+
+        duration_minutes = (
+            read_session_duration_minutes(repo_root) if EVENT == "session-end" else None
+        )
 
         record_event(
             repo_root,
@@ -137,6 +152,7 @@ def record_telemetry(
                 "workflow_items": len(method_items),
                 "open_issues": len(issues),
             },
+            duration_minutes=duration_minutes,
         )
         if EVENT == "session-end":
             auto_commit_snapshot(repo_root)

--- a/repo_context_hooks/telemetry.py
+++ b/repo_context_hooks/telemetry.py
@@ -373,6 +373,8 @@ class UsabilityMetrics:
     readiness_minutes_since_last_event: int | None
     avg_session_duration_minutes: int | None
     max_session_duration_minutes: int | None
+    cold_start_time_saved_minutes: int
+    score_week1_uplift: int | None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -385,6 +387,8 @@ class UsabilityMetrics:
             "readiness_minutes_since_last_event": self.readiness_minutes_since_last_event,
             "avg_session_duration_minutes": self.avg_session_duration_minutes,
             "max_session_duration_minutes": self.max_session_duration_minutes,
+            "cold_start_time_saved_minutes": self.cold_start_time_saved_minutes,
+            "score_week1_uplift": self.score_week1_uplift,
         }
 
 
@@ -573,6 +577,24 @@ def _build_usability(events: list[dict[str, Any]], history: ImpactHistory) -> Us
     avg_dur = round(sum(durations) / len(durations)) if durations else None
     max_dur = max(durations) if durations else None
 
+    # cold start time saved: each post-compact reload prevents ~5 min cold re-orientation
+    cold_start_saved = sum(1 for name in names if "post-compact" in name) * 5
+
+    # week-1 score uplift: score at day 7 minus score at day 0 (None if no day-7 data)
+    score_week1_uplift: int | None = None
+    if len(history.score_series) >= 2:
+        sorted_scores = sorted(history.score_series, key=lambda x: x["date"])
+        day0_date = sorted_scores[0]["date"]
+        day0_score = sorted_scores[0]["score"]
+        try:
+            day0 = dt.date.fromisoformat(day0_date)
+            target = (day0 + dt.timedelta(days=7)).isoformat()
+            candidates = [s for s in sorted_scores if s["date"] >= target]
+            if candidates:
+                score_week1_uplift = candidates[0]["score"] - day0_score
+        except (ValueError, KeyError):
+            pass
+
     return UsabilityMetrics(
         active_days=len(history.daily_event_counts),
         resume_events=sum(1 for name in names if "session-start" in name),
@@ -585,6 +607,8 @@ def _build_usability(events: list[dict[str, Any]], history: ImpactHistory) -> Us
         readiness_minutes_since_last_event=minutes_since_last,
         avg_session_duration_minutes=avg_dur,
         max_session_duration_minutes=max_dur,
+        cold_start_time_saved_minutes=cold_start_saved,
+        score_week1_uplift=score_week1_uplift,
     )
 
 

--- a/repo_context_hooks/telemetry.py
+++ b/repo_context_hooks/telemetry.py
@@ -138,8 +138,27 @@ def is_sampled(repo_root: Path, rate: float = 1.0) -> bool:
     if explicit is not None:
         return explicit.lower() in ("1", "true", "yes")
 
+    # Apply REPO_CONTEXT_HOOKS_SAMPLE_RATE env var before deterministic shortcuts so
+    # the env-var rate is honoured even when no explicit rate= argument is passed.
+    rate_str = os.environ.get("REPO_CONTEXT_HOOKS_SAMPLE_RATE")
+    if rate_str is not None:
+        try:
+            rate = float(rate_str)
+        except ValueError:
+            pass
+
+    # Deterministic rates bypass the file cache to avoid stale-false poisoning the
+    # session.  We still write the canonical value so clear_session_state() and
+    # duration tracking keep working, but we never *read* an old cached value.
     state_dir = _session_state_dir(repo_root)
     sampled_file = state_dir / _SESSION_SAMPLED_FILE
+
+    if rate >= 1.0:
+        sampled_file.write_text("true", encoding="utf-8")
+        return True
+    if rate <= 0.0:
+        sampled_file.write_text("false", encoding="utf-8")
+        return False
 
     if sampled_file.exists():
         age = time.time() - sampled_file.stat().st_mtime
@@ -149,13 +168,6 @@ def is_sampled(repo_root: Path, rate: float = 1.0) -> bool:
         try:
             sampled_file.unlink()
         except OSError:
-            pass
-
-    rate_str = os.environ.get("REPO_CONTEXT_HOOKS_SAMPLE_RATE")
-    if rate_str is not None:
-        try:
-            rate = float(rate_str)
-        except ValueError:
             pass
 
     decision = random.random() < rate

--- a/repo_context_hooks/telemetry.py
+++ b/repo_context_hooks/telemetry.py
@@ -665,6 +665,54 @@ def _lifecycle_donut_svg(coverage: int, r: int = 44) -> str:
     )
 
 
+def _make_test_report(
+    *,
+    current_score: int = 60,
+    reload_events: int = 0,
+    resume_events: int = 5,
+    score_week1_uplift: int | None = None,
+) -> "ImpactReport":
+    """Build a minimal ImpactReport for tests and dashboard snapshots."""
+    now = dt.datetime.now(dt.timezone.utc)
+    history = ImpactHistory(
+        first_seen=now.isoformat(),
+        latest_seen=now.isoformat(),
+        latest_score=current_score,
+        min_score=current_score,
+        max_score=current_score,
+        score_delta=0,
+        daily_event_counts=(),
+        score_series=(),
+        recent_events=(),
+    )
+    usability = UsabilityMetrics(
+        active_days=1,
+        resume_events=resume_events,
+        checkpoint_events=0,
+        reload_events=reload_events,
+        session_end_events=0,
+        lifecycle_coverage=25,
+        readiness_minutes_since_last_event=0,
+        avg_session_duration_minutes=None,
+        max_session_duration_minutes=None,
+        cold_start_time_saved_minutes=reload_events * 5,
+        score_week1_uplift=score_week1_uplift,
+    )
+    return ImpactReport(
+        repo_name="test-repo",
+        repo_id="test-repo",
+        telemetry_path=Path("/tmp/test-telemetry.jsonl"),
+        current_score=current_score,
+        estimated_baseline_score=20,
+        observed_events=resume_events + reload_events,
+        event_counts={},
+        dashboard_path=Path("/tmp/test-dashboard.html"),
+        history=history,
+        usability=usability,
+        recommendations=(),
+    )
+
+
 def render_monitoring_dashboard(
     report: ImpactReport,
     branch_stats: list[Any] | None = None,
@@ -730,6 +778,19 @@ def render_monitoring_dashboard(
     tokens_injected_str = f"{tokens_injected:,}"
     tokens_saved_str = f"{tokens_saved:,}"
     cost_saved_str = f"${cost_saved_usd:.2f}"
+
+    # cold-start time saved
+    cold_start_min = report.usability.cold_start_time_saved_minutes
+    cold_start_str = f"{cold_start_min} min" if cold_start_min > 0 else "—"
+
+    # week-1 score uplift
+    uplift = report.usability.score_week1_uplift
+    if uplift is None:
+        uplift_str = "—"
+    elif uplift >= 0:
+        uplift_str = f"+{uplift}"
+    else:
+        uplift_str = str(uplift)
 
     # lifecycle donut
     donut = _lifecycle_donut_svg(report.usability.lifecycle_coverage)
@@ -867,7 +928,7 @@ def render_monitoring_dashboard(
     }}
     .metric sub {{ font-size: 14px; opacity: .6; }}
     .savings-row {{
-      display: grid; grid-template-columns: repeat(3, minmax(0,1fr));
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
       gap: 14px; margin: 14px 0;
     }}
     .savings-card {{
@@ -994,6 +1055,16 @@ def render_monitoring_dashboard(
           <span>Est. cost saved</span>
           <strong>{cost_saved_str}</strong>
           <em>Claude Sonnet $3/M input tokens</em>
+        </div>
+        <div class="savings-card">
+          <span>Cold starts prevented (est.)</span>
+          <strong>{cold_start_str}</strong>
+          <em>Each context reload saves ~5 min re-orientation</em>
+        </div>
+        <div class="savings-card">
+          <span>Week-1 uplift</span>
+          <strong>{uplift_str}</strong>
+          <em>Score gain from day 0 to day 7</em>
         </div>
       </div>
 

--- a/tests/test_monitoring_surface.py
+++ b/tests/test_monitoring_surface.py
@@ -77,3 +77,30 @@ def test_svg_brand_logo_source_carries_product_language() -> None:
     ]
     for snippet in required:
         assert snippet in text
+
+
+def test_dashboard_contains_cold_start_card():
+    """Dashboard HTML must show the cold start time saved metric."""
+    from repo_context_hooks.telemetry import render_monitoring_dashboard, _make_test_report
+    report = _make_test_report(reload_events=3)  # 3 * 5 = 15 min
+    html = render_monitoring_dashboard(report)
+    assert "Cold starts prevented" in html
+    assert "15 min" in html
+
+
+def test_dashboard_contains_week1_uplift_card():
+    """Dashboard HTML must show the week-1 score uplift when data is available."""
+    from repo_context_hooks.telemetry import render_monitoring_dashboard, _make_test_report
+    report = _make_test_report(score_week1_uplift=25)
+    html = render_monitoring_dashboard(report)
+    assert "Week-1 uplift" in html
+    assert "+25" in html
+
+
+def test_dashboard_uplift_dash_when_none():
+    """Dashboard must show — when score_week1_uplift is None."""
+    from repo_context_hooks.telemetry import render_monitoring_dashboard, _make_test_report
+    report = _make_test_report(score_week1_uplift=None)
+    html = render_monitoring_dashboard(report)
+    assert "Week-1 uplift" in html
+    assert "—" in html  # em-dash rendered when uplift is None

--- a/tests/test_roi_metrics.py
+++ b/tests/test_roi_metrics.py
@@ -1,0 +1,102 @@
+"""Tests for ROI metrics: cold_start_time_saved_minutes and score_week1_uplift."""
+import datetime as dt
+from repo_context_hooks.telemetry import _build_usability, ImpactHistory
+
+
+def _make_history(score_series=None, daily_event_counts=None):
+    now = dt.datetime.now(dt.timezone.utc)
+    score_series = score_series or [{"date": now.strftime("%Y-%m-%d"), "score": 60}]
+    daily = daily_event_counts or [{"date": now.strftime("%Y-%m-%d"), "events": 3}]
+    return ImpactHistory(
+        first_seen=(now - dt.timedelta(days=10)).isoformat(),
+        latest_seen=now.isoformat(),
+        latest_score=score_series[-1]["score"],
+        min_score=min(s["score"] for s in score_series),
+        max_score=max(s["score"] for s in score_series),
+        score_delta=score_series[-1]["score"] - score_series[0]["score"],
+        daily_event_counts=tuple(daily),
+        score_series=tuple(score_series),
+        recent_events=(),
+    )
+
+
+def test_cold_start_time_saved_is_reload_events_times_5():
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60},
+        {"event_name": "post-compact", "timestamp": "2026-04-20T10:30:00+00:00", "repo_contract_score": 60},
+        {"event_name": "post-compact", "timestamp": "2026-04-21T09:00:00+00:00", "repo_contract_score": 65},
+    ]
+    history = _make_history()
+    metrics = _build_usability(events, history)
+    assert metrics.cold_start_time_saved_minutes == 10  # 2 reloads * 5 min
+
+
+def test_cold_start_zero_when_no_reloads():
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60},
+    ]
+    history = _make_history()
+    metrics = _build_usability(events, history)
+    assert metrics.cold_start_time_saved_minutes == 0
+
+
+def test_score_week1_uplift_computes_correctly():
+    base = dt.date(2026, 4, 10)
+    score_series = [
+        {"date": (base + dt.timedelta(days=i)).isoformat(), "score": 40 + i * 5}
+        for i in range(14)
+    ]
+    history = _make_history(score_series=score_series)
+    events = [
+        {
+            "event_name": "session-start",
+            "timestamp": f"{s['date']}T10:00:00+00:00",
+            "repo_contract_score": s["score"],
+        }
+        for s in score_series
+    ]
+    metrics = _build_usability(events, history)
+    # day 0 = score 40, day 7 = score 40 + 7*5 = 75, uplift = 35
+    assert metrics.score_week1_uplift == 35
+
+
+def test_score_week1_uplift_none_when_fewer_than_2_days():
+    score_series = [{"date": "2026-04-20", "score": 60}]
+    history = _make_history(score_series=score_series)
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60}
+    ]
+    metrics = _build_usability(events, history)
+    assert metrics.score_week1_uplift is None
+
+
+def test_score_week1_uplift_none_when_no_day7_data():
+    """If there are only 3 days of data (all within week 1), uplift is None."""
+    base = dt.date(2026, 4, 10)
+    score_series = [
+        {"date": (base + dt.timedelta(days=i)).isoformat(), "score": 50 + i * 3}
+        for i in range(3)  # days 0, 1, 2 — no day 7
+    ]
+    history = _make_history(score_series=score_series)
+    events = [
+        {
+            "event_name": "session-start",
+            "timestamp": f"{s['date']}T10:00:00+00:00",
+            "repo_contract_score": s["score"],
+        }
+        for s in score_series
+    ]
+    metrics = _build_usability(events, history)
+    assert metrics.score_week1_uplift is None
+
+
+def test_roi_metrics_in_to_dict():
+    """Both new fields must appear in to_dict() output."""
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60},
+        {"event_name": "post-compact", "timestamp": "2026-04-20T10:30:00+00:00", "repo_contract_score": 60},
+    ]
+    history = _make_history()
+    d = _build_usability(events, history).to_dict()
+    assert "cold_start_time_saved_minutes" in d
+    assert "score_week1_uplift" in d

--- a/tests/test_session_duration_wiring.py
+++ b/tests/test_session_duration_wiring.py
@@ -1,0 +1,83 @@
+"""Tests that bundle/scripts/repo_specs_memory.py wires session duration tracking."""
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _load_dev_script_record_telemetry():
+    """Return the record_telemetry function from bundle/scripts/repo_specs_memory.py."""
+    script = (
+        Path(__file__).parent.parent
+        / "repo_context_hooks"
+        / "bundle"
+        / "scripts"
+        / "repo_specs_memory.py"
+    )
+    spec = importlib.util.spec_from_file_location("rsmdev", script)
+    mod = importlib.util.module_from_spec(spec)
+    # The script reads a module-level EVENT variable — patch it before exec
+    return mod, spec
+
+
+def test_dev_script_calls_record_session_start_time(tmp_path, monkeypatch):
+    """record_telemetry must call record_session_start_time when EVENT='session-start'."""
+    monkeypatch.setenv("EVENT", "session-start")
+    called = []
+
+    mock_telemetry = MagicMock()
+    mock_telemetry.record_session_start_time.side_effect = lambda r: called.append(r)
+    mock_telemetry.record_event.return_value = tmp_path / "events.jsonl"
+
+    mod, spec = _load_dev_script_record_telemetry()
+    sys.modules["repo_context_hooks.telemetry"] = mock_telemetry
+    try:
+        spec.loader.exec_module(mod)
+        mod.record_telemetry(tmp_path, tmp_path / "specs/README.md", tmp_path / "UL.md")
+    finally:
+        del sys.modules["repo_context_hooks.telemetry"]
+
+    assert len(called) == 1, "record_session_start_time must be called once on session-start"
+
+
+def test_dev_script_passes_duration_on_session_end(tmp_path, monkeypatch):
+    """record_telemetry must pass duration_minutes to record_event when EVENT='session-end'."""
+    monkeypatch.setenv("EVENT", "session-end")
+    captured_kwargs = []
+
+    mock_telemetry = MagicMock()
+    mock_telemetry.read_session_duration_minutes.return_value = 42
+    mock_telemetry.record_event.side_effect = lambda *a, **kw: captured_kwargs.append(kw) or (tmp_path / "events.jsonl")
+
+    mod, spec = _load_dev_script_record_telemetry()
+    sys.modules["repo_context_hooks.telemetry"] = mock_telemetry
+    try:
+        spec.loader.exec_module(mod)
+        mod.record_telemetry(tmp_path, tmp_path / "specs/README.md", tmp_path / "UL.md")
+    finally:
+        del sys.modules["repo_context_hooks.telemetry"]
+
+    assert any(kw.get("duration_minutes") == 42 for kw in captured_kwargs), (
+        f"record_event must receive duration_minutes=42, got: {captured_kwargs}"
+    )
+
+
+def test_dev_script_no_duration_on_session_start(tmp_path, monkeypatch):
+    """record_event must NOT receive duration_minutes on session-start."""
+    monkeypatch.setenv("EVENT", "session-start")
+    captured_kwargs = []
+
+    mock_telemetry = MagicMock()
+    mock_telemetry.record_event.side_effect = lambda *a, **kw: captured_kwargs.append(kw) or (tmp_path / "events.jsonl")
+    mock_telemetry.record_session_start_time.return_value = None
+
+    mod, spec = _load_dev_script_record_telemetry()
+    sys.modules["repo_context_hooks.telemetry"] = mock_telemetry
+    try:
+        spec.loader.exec_module(mod)
+        mod.record_telemetry(tmp_path, tmp_path / "specs/README.md", tmp_path / "UL.md")
+    finally:
+        del sys.modules["repo_context_hooks.telemetry"]
+
+    for kw in captured_kwargs:
+        assert kw.get("duration_minutes") is None, "duration_minutes must be None on session-start"

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -159,7 +159,8 @@ def test_is_sampled_reads_existing_decision_file(monkeypatch) -> None:
     session_dir = _session_state_dir(tmp)
     (session_dir / "current-session-sampled").write_text("true", encoding="utf-8")
 
-    result = is_sampled(tmp)
+    # Use rate=0.5 so the cache file is consulted (deterministic rates bypass it)
+    result = is_sampled(tmp, rate=0.5)
 
     assert result is True
 
@@ -171,7 +172,10 @@ def test_is_sampled_false_decision_file_returns_false(monkeypatch) -> None:
     session_dir = _session_state_dir(tmp)
     (session_dir / "current-session-sampled").write_text("false", encoding="utf-8")
 
-    result = is_sampled(tmp)
+    # Use rate=0.5 so the cache file is consulted (deterministic rates bypass it).
+    # NOTE: rate=1.0 intentionally ignores a cached "false" — that was the bug that
+    # caused 25% lifecycle coverage.  See test_rate_1_ignores_stale_false_cache.
+    result = is_sampled(tmp, rate=0.5)
 
     assert result is False
 

--- a/tests/test_telemetry_sampling_regression.py
+++ b/tests/test_telemetry_sampling_regression.py
@@ -112,6 +112,10 @@ def test_worktree_isolation_independent_sampling_decisions(tmp_path, monkeypatch
 
     If worktrees ever share a state dir accidentally, one worktree's sampled=false
     could suppress another worktree's events.
+
+    Uses rate=0.5 (a non-deterministic rate that reads the file cache) to exercise the
+    isolation property. rate=1.0 and rate=0.0 bypass the cache by design — see
+    test_rate_1_ignores_stale_false_cache / test_rate_0_ignores_stale_true_cache.
     """
     monkeypatch.delenv("REPO_CONTEXT_HOOKS_TELEMETRY", raising=False)
     monkeypatch.delenv("REPO_CONTEXT_HOOKS_SAMPLE_RATE", raising=False)
@@ -131,8 +135,29 @@ def test_worktree_isolation_independent_sampling_decisions(tmp_path, monkeypatch
     (state_a / "current-session-sampled").write_text("true", encoding="utf-8")
     (state_b / "current-session-sampled").write_text("false", encoding="utf-8")
 
-    assert is_sampled(repo_a) is True, "repo_a must be sampled"
-    assert is_sampled(repo_b) is False, "repo_b must not be sampled"
+    # Use rate=0.5 so the cache file is consulted (deterministic rates bypass it)
+    assert is_sampled(repo_a, rate=0.5) is True, "repo_a must be sampled"
+    assert is_sampled(repo_b, rate=0.5) is False, "repo_b must not be sampled"
 
     # repo_a's is_sampled call must not mutate repo_b's state
     assert (state_b / "current-session-sampled").read_text(encoding="utf-8").strip() == "false"
+
+
+def test_rate_1_ignores_stale_false_cache(tmp_path):
+    """rate=1.0 must always return True even if the cache file contains 'false'."""
+    from repo_context_hooks.telemetry import is_sampled, _session_state_dir, _SESSION_SAMPLED_FILE
+    state_dir = _session_state_dir(tmp_path)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / _SESSION_SAMPLED_FILE).write_text("false", encoding="utf-8")
+    for _ in range(100):
+        assert is_sampled(tmp_path, rate=1.0) is True
+
+
+def test_rate_0_ignores_stale_true_cache(tmp_path):
+    """rate=0.0 must always return False even if the cache file contains 'true'."""
+    from repo_context_hooks.telemetry import is_sampled, _session_state_dir, _SESSION_SAMPLED_FILE
+    state_dir = _session_state_dir(tmp_path)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / _SESSION_SAMPLED_FILE).write_text("true", encoding="utf-8")
+    for _ in range(100):
+        assert is_sampled(tmp_path, rate=0.0) is False


### PR DESCRIPTION
## Summary

- **Bug fix:** `is_sampled()` now bypasses stale file cache for deterministic rates (≥1.0 always True, ≤0.0 always False) — resolves the root cause of 0% lifecycle coverage where old 10% sampling decisions were silently blocking pre-compact/post-compact/session-end events
- **Bug fix:** Session duration tracking wired into both bundle script variants (`bundle/scripts/repo_specs_memory.py` and `bundle/skills/.../session_context.py`) — `avg_session_duration_minutes` now populates instead of showing null; also applied `_VALID_EVENTS` validation to prevent pytest argv leaking as EVENT values
- **Feature:** Two new ROI metrics added to `UsabilityMetrics` and the dashboard — "Cold starts prevented (est.)" (`reload_events × 5 min`) and "Week-1 uplift" (score at day 7 minus day 0); `_make_test_report` helper added for future dashboard tests

## Test Plan

- [ ] Run `python -m pytest tests/ -q` — should be 249/249 green
- [ ] Run `python -m repo_context_hooks measure --snapshot-dir docs/monitoring` — should complete without error
- [ ] Open `docs/monitoring/index.html` — confirm "Cold starts prevented (est.)" and "Week-1 uplift" cards visible in savings row
- [ ] Set `REPO_CONTEXT_HOOKS_TELEMETRY=0`, fire a hook, confirm no events recorded (opt-out still works)
- [ ] With default settings, fire session-start + session-end hooks in a test repo, confirm `avg_session_duration_minutes` populates in the snapshot

🤖 Generated with [Claude Code](https://claude.ai/claude-code)