### PR TITLE
feat: shareable export, before/after experiment, and telemetry consent layer

### DIFF
--- a/docs/monitoring/history.json
+++ b/docs/monitoring/history.json
@@ -21,7 +21,7 @@
   "observed_events": 26,
   "repo": "repo-context-hooks",
   "score": 90,
-  "snapshot_at": "2026-04-28T01:57:11Z",
+  "snapshot_at": "2026-04-28T01:59:06Z",
   "time_series": [
     {
       "date": "2026-04-27",
@@ -37,7 +37,7 @@
     "cold_start_time_saved_minutes": 0,
     "lifecycle_coverage": 25,
     "max_session_duration_minutes": null,
-    "readiness_minutes_since_last_event": 205,
+    "readiness_minutes_since_last_event": 207,
     "reload_events": 0,
     "resume_events": 26,
     "score_week1_uplift": null,

--- a/docs/monitoring/history.json
+++ b/docs/monitoring/history.json
@@ -1,49 +1,46 @@
 {
   "baseline": 20,
   "event_counts": {
-    "session-start": 91
+    "session-start": 26
   },
-  "first_seen": "2026-04-26T19:57:31.854624+00:00",
+  "first_seen": "2026-04-27T21:09:50.757559+00:00",
   "forecast": {
     "confidence": "low",
-    "daily_rate": 45.5,
+    "daily_rate": 26.0,
     "projected_active_days": 30,
-    "projected_events": 1365,
+    "projected_events": 780,
     "week_series": [
-      318,
-      318,
-      318,
-      318,
-      91
+      182,
+      182,
+      182,
+      182,
+      52
     ]
   },
-  "latest_seen": "2026-04-27T20:23:22.081254+00:00",
-  "observed_events": 91,
+  "latest_seen": "2026-04-27T22:32:19.320459+00:00",
+  "observed_events": 26,
   "repo": "repo-context-hooks",
   "score": 90,
-  "snapshot_at": "2026-04-27T20:23:31Z",
+  "snapshot_at": "2026-04-28T01:57:11Z",
   "time_series": [
     {
-      "date": "2026-04-26",
-      "events": 13,
-      "score": 90
-    },
-    {
       "date": "2026-04-27",
-      "events": 78,
+      "events": 26,
       "score": 90
     }
   ],
   "uplift": 70,
   "usability": {
-    "active_days": 2,
+    "active_days": 1,
     "avg_session_duration_minutes": null,
     "checkpoint_events": 0,
+    "cold_start_time_saved_minutes": 0,
     "lifecycle_coverage": 25,
     "max_session_duration_minutes": null,
-    "readiness_minutes_since_last_event": 0,
+    "readiness_minutes_since_last_event": 205,
     "reload_events": 0,
-    "resume_events": 91,
+    "resume_events": 26,
+    "score_week1_uplift": null,
     "session_end_events": 0
   }
 }

--- a/docs/monitoring/index.html
+++ b/docs/monitoring/index.html
@@ -168,25 +168,35 @@
         <div class="metric"><span>Contract score</span><strong>90</strong></div>
         <div class="metric"><span>Baseline (no hooks)</span><strong>20</strong></div>
         <div class="metric"><span>Continuity uplift</span><strong>+70</strong></div>
-        <div class="metric"><span>Hook events total</span><strong>91</strong></div>
+        <div class="metric"><span>Hook events total</span><strong>26</strong></div>
       </div>
 
       <!-- Context savings row -->
       <div class="savings-row">
         <div class="savings-card">
           <span>Tokens injected</span>
-          <strong>409,500</strong>
-          <em>~4,500 tok/session × 91 sessions</em>
+          <strong>117,000</strong>
+          <em>~4,500 tok/session × 26 sessions</em>
         </div>
         <div class="savings-card">
           <span>Tokens saved (est.)</span>
-          <strong>54,600</strong>
+          <strong>15,600</strong>
           <em>30% of sessions avoid 2,000-tok re-orientation</em>
         </div>
         <div class="savings-card">
           <span>Est. cost saved</span>
-          <strong>$0.16</strong>
+          <strong>$0.05</strong>
           <em>Claude Sonnet $3/M input tokens</em>
+        </div>
+        <div class="savings-card">
+          <span>Cold starts prevented (est.)</span>
+          <strong>—</strong>
+          <em>Each context reload saves ~5 min re-orientation</em>
+        </div>
+        <div class="savings-card">
+          <span>Week-1 uplift</span>
+          <strong>—</strong>
+          <em>Score gain from day 0 to day 7</em>
         </div>
       </div>
 
@@ -194,12 +204,11 @@
       <div class="grid">
         <section class="panel">
           <h2>Daily activity</h2>
-          <div class="bar-row"><span>2026-04-26</span><div class="bar-track"><div class="bar-fill" style="width:17%"></div></div><strong>13</strong></div>
-<div class="bar-row"><span>2026-04-27</span><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><strong>78</strong></div>
+          <div class="bar-row"><span>2026-04-27</span><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><strong>26</strong></div>
         </section>
         <section class="panel">
           <h2>Event mix</h2>
-          <div class="events"><div><span>session-start</span><strong>91</strong></div></div>
+          <div class="events"><div><span>session-start</span><strong>26</strong></div></div>
         </section>
       </div>
 
@@ -214,14 +223,13 @@
                 25% of the 4-event lifecycle is instrumented.
                 session-start is active. session-end, pre-compact, and post-compact will populate after longer sessions.
               </p>
-              <div class="lc-grid"><div class="lc-pill lc-active"><span>session-start</span><strong>91</strong></div><div class="lc-pill lc-empty"><span>pre-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>post-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>session-end</span><strong>0</strong></div></div>
+              <div class="lc-grid"><div class="lc-pill lc-active"><span>session-start</span><strong>26</strong></div><div class="lc-pill lc-empty"><span>pre-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>post-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>session-end</span><strong>0</strong></div></div>
             </div>
           </div>
         </section>
         <section class="panel">
           <h2>Score history</h2>
-          <div class="score-point"><span>2026-04-26</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
-<div class="score-point"><span>2026-04-27</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
+          <div class="score-point"><span>2026-04-27</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
         </section>
       </div>
 
@@ -241,8 +249,8 @@
         <section class="panel">
           <h2>Usability metrics</h2>
           <div class="usability">
-            <div><span>Active days</span><strong>2</strong></div>
-            <div><span>Sessions</span><strong>91</strong></div>
+            <div><span>Active days</span><strong>1</strong></div>
+            <div><span>Sessions</span><strong>26</strong></div>
             <div><span>Checkpoints</span><strong>0</strong></div>
             <div><span>Reloads</span><strong>0</strong></div>
             <div><span>Session ends</span><strong>0</strong></div>
@@ -257,11 +265,11 @@
         <section class="panel">
           <h2>30-day forecast <small style="font-size:14px;font-weight:400;opacity:.6">confidence: low</small></h2>
           <div class="metrics4">
-            <div class="metric"><span>Daily rate</span><strong>45.5</strong></div>
-            <div class="metric"><span>Projected events</span><strong>1,365</strong></div>
+            <div class="metric"><span>Daily rate</span><strong>26.0</strong></div>
+            <div class="metric"><span>Projected events</span><strong>780</strong></div>
             <div class="metric"><span>Active days (30d)</span><strong>30</strong></div>
           </div>
-          <div class="fc-grid"><div class="fc-week"><span>Week 1</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 2</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 3</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 4</span><strong>318</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 5</span><strong>91</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div></div>
+          <div class="fc-grid"><div class="fc-week"><span>Week 1</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 2</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 3</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 4</span><strong>182</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 5</span><strong>52</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div></div>
         </section>
         <section class="panel">
           <h2>Platform proof</h2>

--- a/repo_context_hooks/bundle/scripts/repo_specs_memory.py
+++ b/repo_context_hooks/bundle/scripts/repo_specs_memory.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
 
-EVENT = sys.argv[1] if len(sys.argv) > 1 else "session-start"
+_VALID_EVENTS = {"session-start", "pre-compact", "post-compact", "session-end"}
+_raw_env = os.environ.get("EVENT", "")
+EVENT: str = (
+    _raw_env if _raw_env in _VALID_EVENTS
+    else (sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] in _VALID_EVENTS else "session-start")
+)
 
 AUTO_BLOCK_START = "<!-- AUTO:REPO_CONTEXT_START -->"
 AUTO_BLOCK_END = "<!-- AUTO:REPO_CONTEXT_END -->"
@@ -205,13 +211,25 @@ def record_telemetry(repo_root: Path, specs_readme: Path, ul_path: Path) -> None
                 sys.path.insert(0, str(parent))
                 break
 
-        from repo_context_hooks.telemetry import record_event
+        from repo_context_hooks.telemetry import (
+            read_session_duration_minutes,
+            record_event,
+            record_session_start_time,
+        )
+
+        if EVENT == "session-start":
+            record_session_start_time(repo_root)
+
+        duration_minutes = (
+            read_session_duration_minutes(repo_root) if EVENT == "session-end" else None
+        )
 
         event_path = record_event(
             repo_root,
             EVENT,
             source="repo_specs_memory",
             details={"specs_readme": str(specs_readme), "glossary": str(ul_path)},
+            duration_minutes=duration_minutes,
         )
         print(f"- Telemetry: `{event_path}`")
     except Exception:

--- a/repo_context_hooks/bundle/skills/context-handoff-hooks/scripts/session_context.py
+++ b/repo_context_hooks/bundle/skills/context-handoff-hooks/scripts/session_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -8,7 +9,12 @@ import sys
 from pathlib import Path
 
 
-EVENT = sys.argv[1] if len(sys.argv) > 1 else "session-start"
+_VALID_EVENTS = {"session-start", "pre-compact", "post-compact", "session-end"}
+_raw_env = os.environ.get("EVENT", "")
+EVENT: str = (
+    _raw_env if _raw_env in _VALID_EVENTS
+    else (sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] in _VALID_EVENTS else "session-start")
+)
 
 
 def git_output(*args: str) -> str:
@@ -120,13 +126,22 @@ def record_telemetry(
             auto_commit_snapshot,
             clear_session_state,
             is_sampled,
+            read_session_duration_minutes,
             record_event,
+            record_session_start_time,
         )
 
         if not is_sampled(repo_root):
             if EVENT == "session-end":
                 clear_session_state(repo_root)
             return
+
+        if EVENT == "session-start":
+            record_session_start_time(repo_root)
+
+        duration_minutes = (
+            read_session_duration_minutes(repo_root) if EVENT == "session-end" else None
+        )
 
         record_event(
             repo_root,
@@ -137,6 +152,7 @@ def record_telemetry(
                 "workflow_items": len(method_items),
                 "open_issues": len(issues),
             },
+            duration_minutes=duration_minutes,
         )
         if EVENT == "session-end":
             auto_commit_snapshot(repo_root)

--- a/repo_context_hooks/cli.py
+++ b/repo_context_hooks/cli.py
@@ -10,7 +10,15 @@ from .platforms import get_registry
 from .recommend import recommend_setup
 from .repo_contract import init_repo_contract
 from .doctor import diagnose_repo_contract
-from .telemetry import measure_impact, write_public_monitoring_snapshot
+from .telemetry import (
+    experiment_finish,
+    experiment_start,
+    experiment_status,
+    export_impact_report,
+    measure_impact,
+    write_public_monitoring_snapshot,
+)
+from . import consent as _consent_mod
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -187,6 +195,43 @@ def build_parser() -> argparse.ArgumentParser:
         dest="dry_run",
         help="Actually delete ghost repos (use with --clean-ghosts).",
     )
+    measure.add_argument(
+        "positional_args",
+        nargs="*",
+        metavar="SUBCOMMAND [ARGS...]",
+        help=(
+            "Sub-commands: "
+            "'export [--format markdown|json]' — redacted shareable impact report; "
+            "'experiment [start|finish|status]' — guided before/after continuity experiment."
+        ),
+    )
+    measure.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format for 'export' (default: markdown).",
+    )
+    measure.add_argument(
+        "--redact",
+        action="store_true",
+        default=True,
+        help="Redact local filesystem paths from the export (default: on; always enforced).",
+    )
+    measure.add_argument(
+        "--output",
+        "-o",
+        metavar="PATH",
+        help="Write export output to this file path instead of stdout.",
+    )
+    measure.add_argument(
+        "--experiment-dir",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Directory to store before.json/after.json for experiments "
+            "(default: .repo-context-hooks/experiment in the repo root)."
+        ),
+    )
 
     platforms = subparsers.add_parser(
         "platforms",
@@ -207,6 +252,57 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         choices=supported_platform_ids(),
         help="Platform to uninstall.",
+    )
+
+    checkpoint = subparsers.add_parser(
+        "checkpoint",
+        help="Append a decision/handoff summary to specs/README.md Session Log.",
+    )
+    checkpoint.add_argument(
+        "--message",
+        required=True,
+        help="Decision summary to record (what was built, key decisions, next step).",
+    )
+    checkpoint.add_argument(
+        "--path",
+        default=".",
+        help="Repository root (default: current directory).",
+    )
+
+    telemetry = subparsers.add_parser(
+        "telemetry",
+        help="Manage remote telemetry consent (opt-in, local config only).",
+    )
+    telemetry_sub = telemetry.add_subparsers(dest="telemetry_subcommand", required=True)
+
+    telemetry_sub.add_parser(
+        "status",
+        help="Show the current remote telemetry consent state.",
+    )
+
+    telemetry_enable = telemetry_sub.add_parser(
+        "enable",
+        help="Opt in to remote telemetry. Shows consent text and prompts for confirmation.",
+    )
+    telemetry_enable.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip interactive confirmation prompt (for CI/non-interactive use).",
+    )
+
+    telemetry_sub.add_parser(
+        "disable",
+        help="Opt out of remote telemetry.",
+    )
+
+    telemetry_preview = telemetry_sub.add_parser(
+        "preview",
+        help="Preview the payload that would be sent if telemetry were enabled.",
+    )
+    telemetry_preview.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repository root to include continuity score in the preview (optional).",
     )
 
     return parser
@@ -372,6 +468,14 @@ def _uninstall(args: argparse.Namespace) -> int:
     return 0
 
 
+def _resolve_experiment_dir(args: argparse.Namespace, repo_root: Path) -> Path:
+    raw = getattr(args, "experiment_dir", None)
+    if raw:
+        p = Path(raw)
+        return p if p.is_absolute() else repo_root / p
+    return repo_root / ".repo-context-hooks" / "experiment"
+
+
 def _measure(args: argparse.Namespace) -> int:
     if getattr(args, "clean_ghosts", False):
         from .telemetry import purge_ghost_repos
@@ -388,6 +492,48 @@ def _measure(args: argparse.Namespace) -> int:
         return 0
 
     repo_root = Path(args.repo_root).resolve()
+
+    positional = list(getattr(args, "positional_args", None) or [])
+
+    if positional and positional[0] == "export":
+        report = measure_impact(repo_root=repo_root)
+        output = export_impact_report(
+            report,
+            format=getattr(args, "format", "markdown"),
+            redact=True,
+        )
+        out_path = getattr(args, "output", None)
+        if out_path:
+            Path(out_path).write_text(output, encoding="utf-8")
+            print(f"Export written to: {out_path}")
+        else:
+            print(output)
+        return 0
+
+    if positional and positional[0] == "experiment":
+        exp_dir = _resolve_experiment_dir(args, repo_root)
+        sub = positional[1] if len(positional) > 1 else "status"
+        if sub == "start":
+            try:
+                before_path = experiment_start(repo_root, exp_dir)
+                print(f"Before snapshot: {before_path}")
+            except FileExistsError as exc:
+                print(f"Error: {exc}")
+                return 1
+        elif sub == "finish":
+            try:
+                experiment_finish(repo_root, exp_dir)
+            except FileNotFoundError as exc:
+                print(f"Error: {exc}")
+                return 1
+        elif sub == "status":
+            status = experiment_status(exp_dir)
+            print(status["message"])
+        else:
+            print(f"Unknown experiment subcommand: {sub!r}")
+            print("Usage: repo-context-hooks measure experiment [start|finish|status]")
+            return 1
+        return 0
 
     if getattr(args, "forecast", False):
         from .telemetry import forecast_activity
@@ -459,6 +605,113 @@ def _measure(args: argparse.Namespace) -> int:
     return 0
 
 
+def _checkpoint(args: argparse.Namespace) -> int:
+    import subprocess
+    import sys
+
+    repo_root_raw = ""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=args.path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        repo_root_raw = result.stdout.strip()
+    except Exception:
+        pass
+
+    if not repo_root_raw:
+        print("error: no git repo found at the specified path")
+        return 1
+
+    specs_readme = Path(repo_root_raw) / "specs" / "README.md"
+    if not specs_readme.exists():
+        print("error: no workspace contract found — run `repo-context-hooks init` first")
+        return 1
+
+    bundle_script = Path(__file__).parent / "bundle" / "skills" / "context-handoff-hooks" / "scripts" / "repo_specs_memory.py"
+    result = subprocess.run(
+        [sys.executable, str(bundle_script), "decision", "--message", args.message],
+        cwd=repo_root_raw,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(result.stderr.strip())
+        return result.returncode
+
+    print(result.stdout.strip())
+    return 0
+
+
+def _telemetry_cmd(args: argparse.Namespace) -> int:
+    sub = args.telemetry_subcommand
+
+    if sub == "status":
+        state = _consent_mod.get_consent_state()
+        status = state["status"]
+        config_path = state["config_path"]
+
+        if status == "enabled":
+            print(f"Remote telemetry: enabled")
+            print(f"Install ID: {state['install_id']}")
+            if state["enabled_at"]:
+                print(f"Enabled at: {state['enabled_at']}")
+            print(f"Config: {config_path}")
+            print("Note: Remote collector endpoint not yet configured. No data is being sent.")
+        elif status == "disabled":
+            print("Remote telemetry: disabled")
+            print(f"Config: {config_path}")
+        else:
+            print("Remote telemetry: not configured")
+            print("Install ID: (will be generated on first enable)")
+            print(f"Config: {config_path}")
+        return 0
+
+    if sub == "enable":
+        use_yes = getattr(args, "yes", False)
+        if not use_yes:
+            # Interactive mode: show consent text and prompt.
+            print(_consent_mod.CONSENT_TEXT)
+            print()
+            try:
+                answer = input("Enable remote telemetry? [y/N]: ").strip().lower()
+            except (EOFError, OSError):
+                # Non-interactive environment without --yes flag.
+                print("Non-interactive environment detected. Use --yes to skip the prompt.")
+                print("Telemetry remains disabled.")
+                return 0
+            if answer not in ("y", "yes"):
+                print("Telemetry remains disabled.")
+                return 0
+
+        state = _consent_mod.enable_consent()
+        print("Remote telemetry enabled.")
+        print(f"Install ID: {state['install_id']}")
+        print(f"Config: {state['config_path']}")
+        print("Note: Remote collector endpoint not yet configured. No data is being sent.")
+        return 0
+
+    if sub == "disable":
+        state = _consent_mod.disable_consent()
+        print("Remote telemetry disabled.")
+        print(f"Config: {state['config_path']}")
+        return 0
+
+    if sub == "preview":
+        repo_root: Path | None = None
+        raw_root = getattr(args, "repo_root", None)
+        if raw_root is not None:
+            repo_root = Path(raw_root).resolve()
+        payload = _consent_mod.preview_payload(repo_root=repo_root)
+        _print_json(payload)
+        return 0
+
+    return 0
+
+
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
@@ -476,5 +729,9 @@ def main() -> int:
         return _measure(args)
     if args.command == "uninstall":
         return _uninstall(args)
+    if args.command == "checkpoint":
+        return _checkpoint(args)
+    if args.command == "telemetry":
+        return _telemetry_cmd(args)
     parser.error("Unknown command")
     return 2

--- a/repo_context_hooks/consent.py
+++ b/repo_context_hooks/consent.py
@@ -1,0 +1,192 @@
+"""Consent management for remote telemetry.
+
+Manages the local consent config file. No data is sent remotely until a real
+collector endpoint exists, a published privacy policy is in place, and this
+module is wired to an actual upload path.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+CONSENT_TEXT = """\
+repo-context-hooks can optionally send privacy-preserving usage metrics to the \
+maintainer so the community can see adoption and continuity impact.
+
+Collected: anonymous install id, package version, platform adapter, lifecycle \
+event counts, continuity score, estimated baseline score, and coarse OS/runtime \
+information.
+
+Never collected: source code, prompts, compact summaries, issue bodies, secrets, \
+environment values, resumes, or personal files.
+
+Remote telemetry is optional and can be disabled at any time.\
+"""
+
+# Allow tests to override the config path via this module-level variable.
+_CONFIG_PATH_OVERRIDE: Path | None = None
+
+
+def consent_config_path() -> Path:
+    """Return the platform-appropriate path to the consent config file."""
+    if _CONFIG_PATH_OVERRIDE is not None:
+        return _CONFIG_PATH_OVERRIDE
+
+    if os.name == "nt":
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if local_app_data:
+            base = Path(local_app_data) / "repo-context-hooks"
+        else:
+            base = Path.home() / "AppData" / "Local" / "repo-context-hooks"
+    else:
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        if xdg:
+            base = Path(xdg) / "repo-context-hooks"
+        else:
+            base = Path.home() / ".config" / "repo-context-hooks"
+
+    return base / "consent.json"
+
+
+def _read_config() -> dict[str, Any]:
+    path = consent_config_path()
+    if not path.exists():
+        return {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return data
+    except (json.JSONDecodeError, OSError):
+        pass
+    return {}
+
+
+def _write_config(data: dict[str, Any]) -> None:
+    path = consent_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def get_consent_state() -> dict[str, Any]:
+    """Return the current consent state.
+
+    Returns a dict with keys:
+      - status: "enabled" | "disabled" | "not_set"
+      - enabled_at: ISO timestamp string or None
+      - install_id: UUID string or None
+      - config_path: path to the config file (as string)
+    """
+    cfg = _read_config()
+    consented = cfg.get("consented")
+    if consented is True:
+        status = "enabled"
+    elif consented is False:
+        status = "disabled"
+    else:
+        status = "not_set"
+
+    return {
+        "status": status,
+        "enabled_at": cfg.get("enabled_at"),
+        "install_id": cfg.get("install_id"),
+        "config_path": str(consent_config_path()),
+    }
+
+
+def enable_consent() -> dict[str, Any]:
+    """Write consent=True to the config. Generate install_id if not present.
+
+    Returns the new consent state dict.
+    """
+    cfg = _read_config()
+    if not cfg.get("install_id"):
+        cfg["install_id"] = str(uuid.uuid4())
+    cfg["consented"] = True
+    cfg["enabled_at"] = dt.datetime.now(dt.timezone.utc).isoformat()
+    _write_config(cfg)
+    return get_consent_state()
+
+
+def disable_consent() -> dict[str, Any]:
+    """Write consent=False to the config.
+
+    Returns the new consent state dict.
+    """
+    cfg = _read_config()
+    cfg["consented"] = False
+    _write_config(cfg)
+    return get_consent_state()
+
+
+def is_consented() -> bool:
+    """Return True only if consent status is explicitly 'enabled'."""
+    return get_consent_state()["status"] == "enabled"
+
+
+def preview_payload(repo_root: Path | None = None) -> dict[str, Any]:
+    """Return the payload that WOULD be sent if consent is given.
+
+    No local paths are included. This is safe to display to users.
+    """
+    state = get_consent_state()
+    install_id = state["install_id"] or "not-yet-generated"
+
+    # Resolve package version without leaking local paths.
+    package_version = _get_package_version()
+
+    continuity_score = None
+    estimated_baseline_score = None
+    lifecycle_event_counts: dict[str, int] = {}
+
+    if repo_root is not None:
+        try:
+            from .telemetry import measure_impact
+            report = measure_impact(repo_root=repo_root)
+            continuity_score = report.current_score
+            estimated_baseline_score = report.estimated_baseline_score
+            lifecycle_event_counts = dict(report.event_counts)
+        except Exception:
+            pass
+
+    return {
+        "install_id": install_id,
+        "package_version": package_version,
+        "platform_adapter": "unknown",
+        "os_family": sys.platform,
+        "python_minor": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "continuity_score": continuity_score,
+        "estimated_baseline_score": estimated_baseline_score,
+        "lifecycle_event_counts": lifecycle_event_counts,
+        "collector_endpoint": "not yet configured",
+        "disclaimer": "This is a preview of data that WOULD be sent. No data has been sent.",
+    }
+
+
+def _get_package_version() -> str:
+    """Return the installed package version, with a pyproject.toml fallback."""
+    try:
+        from importlib.metadata import version as _meta_version
+        return _meta_version("repo-context-hooks")
+    except Exception:
+        pass
+
+    # Fallback: read from pyproject.toml next to the package root.
+    try:
+        import re
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        if pyproject.exists():
+            text = pyproject.read_text(encoding="utf-8")
+            match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+            if match:
+                return match.group(1)
+    except Exception:
+        pass
+
+    return "unknown"

--- a/repo_context_hooks/telemetry.py
+++ b/repo_context_hooks/telemetry.py
@@ -373,6 +373,8 @@ class UsabilityMetrics:
     readiness_minutes_since_last_event: int | None
     avg_session_duration_minutes: int | None
     max_session_duration_minutes: int | None
+    cold_start_time_saved_minutes: int
+    score_week1_uplift: int | None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -385,6 +387,8 @@ class UsabilityMetrics:
             "readiness_minutes_since_last_event": self.readiness_minutes_since_last_event,
             "avg_session_duration_minutes": self.avg_session_duration_minutes,
             "max_session_duration_minutes": self.max_session_duration_minutes,
+            "cold_start_time_saved_minutes": self.cold_start_time_saved_minutes,
+            "score_week1_uplift": self.score_week1_uplift,
         }
 
 
@@ -573,6 +577,24 @@ def _build_usability(events: list[dict[str, Any]], history: ImpactHistory) -> Us
     avg_dur = round(sum(durations) / len(durations)) if durations else None
     max_dur = max(durations) if durations else None
 
+    # cold start time saved: each post-compact reload prevents ~5 min cold re-orientation
+    cold_start_saved = sum(1 for name in names if "post-compact" in name) * 5
+
+    # week-1 score uplift: score at day 7 minus score at day 0 (None if no day-7 data)
+    score_week1_uplift: int | None = None
+    if len(history.score_series) >= 2:
+        sorted_scores = sorted(history.score_series, key=lambda x: x["date"])
+        day0_date = sorted_scores[0]["date"]
+        day0_score = sorted_scores[0]["score"]
+        try:
+            day0 = dt.date.fromisoformat(day0_date)
+            target = (day0 + dt.timedelta(days=7)).isoformat()
+            candidates = [s for s in sorted_scores if s["date"] >= target]
+            if candidates:
+                score_week1_uplift = candidates[0]["score"] - day0_score
+        except (ValueError, KeyError):
+            pass
+
     return UsabilityMetrics(
         active_days=len(history.daily_event_counts),
         resume_events=sum(1 for name in names if "session-start" in name),
@@ -585,6 +607,8 @@ def _build_usability(events: list[dict[str, Any]], history: ImpactHistory) -> Us
         readiness_minutes_since_last_event=minutes_since_last,
         avg_session_duration_minutes=avg_dur,
         max_session_duration_minutes=max_dur,
+        cold_start_time_saved_minutes=cold_start_saved,
+        score_week1_uplift=score_week1_uplift,
     )
 
 

--- a/repo_context_hooks/telemetry.py
+++ b/repo_context_hooks/telemetry.py
@@ -138,8 +138,27 @@ def is_sampled(repo_root: Path, rate: float = 1.0) -> bool:
     if explicit is not None:
         return explicit.lower() in ("1", "true", "yes")
 
+    # Apply REPO_CONTEXT_HOOKS_SAMPLE_RATE env var before deterministic shortcuts so
+    # the env-var rate is honoured even when no explicit rate= argument is passed.
+    rate_str = os.environ.get("REPO_CONTEXT_HOOKS_SAMPLE_RATE")
+    if rate_str is not None:
+        try:
+            rate = float(rate_str)
+        except ValueError:
+            pass
+
+    # Deterministic rates bypass the file cache to avoid stale-false poisoning the
+    # session.  We still write the canonical value so clear_session_state() and
+    # duration tracking keep working, but we never *read* an old cached value.
     state_dir = _session_state_dir(repo_root)
     sampled_file = state_dir / _SESSION_SAMPLED_FILE
+
+    if rate >= 1.0:
+        sampled_file.write_text("true", encoding="utf-8")
+        return True
+    if rate <= 0.0:
+        sampled_file.write_text("false", encoding="utf-8")
+        return False
 
     if sampled_file.exists():
         age = time.time() - sampled_file.stat().st_mtime
@@ -149,13 +168,6 @@ def is_sampled(repo_root: Path, rate: float = 1.0) -> bool:
         try:
             sampled_file.unlink()
         except OSError:
-            pass
-
-    rate_str = os.environ.get("REPO_CONTEXT_HOOKS_SAMPLE_RATE")
-    if rate_str is not None:
-        try:
-            rate = float(rate_str)
-        except ValueError:
             pass
 
     decision = random.random() < rate

--- a/repo_context_hooks/telemetry.py
+++ b/repo_context_hooks/telemetry.py
@@ -1460,6 +1460,244 @@ def measure_impact(repo_root: Path, telemetry_base: Path | None = None) -> Impac
     return report
 
 
+_EXPERIMENT_BEFORE = "before.json"
+_EXPERIMENT_AFTER = "after.json"
+
+
+def _make_experiment_snapshot(repo_root: Path) -> dict[str, Any]:
+    """Build a redacted snapshot dict from a current measure_impact call."""
+    report = measure_impact(repo_root)
+    signals = contract_signals(repo_root)
+    contract_files_present: dict[str, bool] = dict(signals["present"])
+    return {
+        "timestamp": dt.datetime.now(dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "score": report.current_score,
+        "baseline": report.estimated_baseline_score,
+        "uplift": report.uplift,
+        "observed_events": report.observed_events,
+        "event_counts": dict(sorted(report.event_counts.items())),
+        "lifecycle_coverage": report.usability.lifecycle_coverage,
+        "contract_files_present": contract_files_present,
+    }
+
+
+def experiment_start(repo_root: Path, experiment_dir: Path) -> Path:
+    """Snapshot current state as before.json. Returns path to before.json."""
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    before_path = experiment_dir / _EXPERIMENT_BEFORE
+    if before_path.exists():
+        raise FileExistsError(
+            f"An experiment is already in progress ({before_path}). "
+            "Run `repo-context-hooks measure experiment finish` to complete it, "
+            "or delete before.json manually to start over."
+        )
+    snapshot = _make_experiment_snapshot(repo_root)
+    before_path.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print("Experiment started. Make your setup changes, then run:")
+    print("  repo-context-hooks measure experiment finish")
+    return before_path
+
+
+def experiment_finish(repo_root: Path, experiment_dir: Path) -> dict[str, Any]:
+    """Snapshot current state as after.json, compute comparison. Returns comparison dict."""
+    before_path = experiment_dir / _EXPERIMENT_BEFORE
+    if not before_path.exists():
+        raise FileNotFoundError(
+            "No experiment in progress. "
+            "Run `repo-context-hooks measure experiment start` first."
+        )
+    before = json.loads(before_path.read_text(encoding="utf-8"))
+    after = _make_experiment_snapshot(repo_root)
+
+    after_path = experiment_dir / _EXPERIMENT_AFTER
+    after_path.write_text(json.dumps(after, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    score_delta = after["score"] - before["score"]
+    uplift_delta = after["uplift"] - before["uplift"]
+    events_delta = after["observed_events"] - before["observed_events"]
+
+    before_files = {f for f, present in before.get("contract_files_present", {}).items() if present}
+    after_files = {f for f, present in after.get("contract_files_present", {}).items() if present}
+    new_files = sorted(after_files - before_files)
+
+    parts: list[str] = []
+    if score_delta > 0:
+        parts.append(f"Continuity score improved by +{score_delta} (from {before['score']} to {after['score']}).")
+    elif score_delta < 0:
+        parts.append(f"Continuity score decreased by {score_delta} (from {before['score']} to {after['score']}).")
+    else:
+        parts.append(f"Continuity score unchanged at {after['score']}.")
+    if new_files:
+        parts.append(f"{len(new_files)} new contract file(s) added: {', '.join(new_files)}.")
+    if events_delta > 0:
+        parts.append(f"{events_delta} new hook event(s) observed.")
+    if uplift_delta > 0:
+        parts.append(f"Repo contract uplift increased by +{uplift_delta}.")
+    elif uplift_delta < 0:
+        parts.append(f"Repo contract uplift decreased by {uplift_delta}.")
+    summary = " ".join(parts)
+
+    comparison: dict[str, Any] = {
+        "before": before,
+        "after": after,
+        "score_delta": score_delta,
+        "uplift_delta": uplift_delta,
+        "events_delta": events_delta,
+        "new_files": new_files,
+        "summary": summary,
+    }
+
+    print("=== Experiment complete ===")
+    print(summary)
+    print(f"Before score: {before['score']}  ->  After score: {after['score']}  (delta: {score_delta:+d})")
+    print(f"Lifecycle coverage: {before['lifecycle_coverage']}% -> {after['lifecycle_coverage']}%")
+    if new_files:
+        print("New files:")
+        for f in new_files:
+            print(f"  + {f}")
+    print(f"Results written to: {experiment_dir}")
+    return comparison
+
+
+def experiment_status(experiment_dir: Path) -> dict[str, Any]:
+    """Return state of the current experiment."""
+    before_path = experiment_dir / _EXPERIMENT_BEFORE
+    after_path = experiment_dir / _EXPERIMENT_AFTER
+
+    if before_path.exists() and after_path.exists():
+        return {
+            "state": "finished",
+            "message": (
+                "Experiment complete. "
+                "Run `repo-context-hooks measure experiment start` to begin a new one "
+                "(delete before.json and after.json first)."
+            ),
+        }
+    if before_path.exists():
+        try:
+            before = json.loads(before_path.read_text(encoding="utf-8"))
+            ts = before.get("timestamp", "unknown")
+        except Exception:
+            ts = "unknown"
+        return {
+            "state": "in_progress",
+            "message": f"Experiment in progress. Before snapshot taken at {ts}.",
+        }
+    return {
+        "state": "not_started",
+        "message": "No experiment in progress. Run `repo-context-hooks measure experiment start` to begin.",
+    }
+
+
+_EXPORT_DISCLAIMER = (
+    "local operational telemetry — no source code, prompts, or personal data"
+)
+
+
+def export_impact_report(
+    report: "ImpactReport",
+    format: str = "markdown",
+    redact: bool = True,
+) -> str:
+    """Return a redacted shareable export of the impact report.
+
+    Includes: repo name (basename only), scores, event counts, usability
+    metrics, and timestamps (date-only).
+    Excludes: telemetry_path, dashboard_path, repo_id, any local filesystem
+    paths.
+    """
+    # Date-only timestamps (strip time component to avoid leaking session timing precision)
+    first_seen_date = (report.history.first_seen or "")[:10] or None
+    latest_seen_date = (report.history.latest_seen or "")[:10] or None
+    u = report.usability
+
+    if format == "json":
+        payload: dict[str, Any] = {
+            "generated_at": dt.datetime.now(dt.timezone.utc).date().isoformat(),
+            "disclaimer": _EXPORT_DISCLAIMER,
+            "repo": report.repo_name,
+            "score": report.current_score,
+            "baseline": report.estimated_baseline_score,
+            "uplift": report.uplift,
+            "observed_events": report.observed_events,
+            "event_counts": dict(sorted(report.event_counts.items())),
+            "active_days": u.active_days,
+            "lifecycle_coverage_pct": u.lifecycle_coverage,
+            "resume_events": u.resume_events,
+            "checkpoint_events": u.checkpoint_events,
+            "reload_events": u.reload_events,
+            "avg_session_duration_minutes": u.avg_session_duration_minutes,
+            "cold_start_time_saved_minutes": u.cold_start_time_saved_minutes,
+            "score_week1_uplift": u.score_week1_uplift,
+            "first_seen": first_seen_date,
+            "latest_seen": latest_seen_date,
+        }
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+    # Markdown format
+    def _val(v: Any) -> str:
+        if v is None:
+            return "-"
+        return str(v)
+
+    uplift_str = f"+{report.uplift}" if report.uplift >= 0 else str(report.uplift)
+    w1_str = (
+        f"+{u.score_week1_uplift}" if u.score_week1_uplift is not None and u.score_week1_uplift >= 0
+        else _val(u.score_week1_uplift)
+    )
+
+    rows = [
+        ("Contract score", _val(report.current_score)),
+        ("Baseline (no hooks)", _val(report.estimated_baseline_score)),
+        ("Continuity uplift", uplift_str),
+        ("Observed events", _val(report.observed_events)),
+        ("Active days", _val(u.active_days)),
+        ("Lifecycle coverage", f"{u.lifecycle_coverage}%"),
+        ("Sessions (resume events)", _val(u.resume_events)),
+        ("Checkpoint events", _val(u.checkpoint_events)),
+        ("Context reloads (post-compact)", _val(u.reload_events)),
+        ("Avg session duration (min)", _val(u.avg_session_duration_minutes)),
+        ("Cold-start time saved (min)", _val(u.cold_start_time_saved_minutes)),
+        ("Week-1 score uplift", w1_str),
+        ("First seen (date)", _val(first_seen_date)),
+        ("Latest seen (date)", _val(latest_seen_date)),
+    ]
+
+    table_lines = [
+        "| Metric | Value |",
+        "|---|---|",
+    ]
+    table_lines.extend(f"| {metric} | {value} |" for metric, value in rows)
+
+    event_count_lines: list[str] = []
+    if report.event_counts:
+        event_count_lines.append("")
+        event_count_lines.append("### Event breakdown")
+        event_count_lines.append("")
+        event_count_lines.append("| Event | Count |")
+        event_count_lines.append("|---|---|")
+        for name, count in sorted(report.event_counts.items()):
+            event_count_lines.append(f"| {name} | {count} |")
+
+    parts = [
+        f"## repo-context-hooks Impact Report — {report.repo_name}",
+        "",
+        "\n".join(table_lines),
+    ]
+    if event_count_lines:
+        parts.append("\n".join(event_count_lines))
+    parts.append("")
+    parts.append(
+        f"*Source: {_EXPORT_DISCLAIMER}. "
+        "Generated by [repo-context-hooks](https://github.com/narendranathe/repo-context-hooks).*"
+    )
+
+    return "\n".join(parts)
+
+
 def auto_commit_snapshot(
     repo_root: Path,
     telemetry_base: Path | None = None,

--- a/repo_context_hooks/telemetry.py
+++ b/repo_context_hooks/telemetry.py
@@ -665,6 +665,54 @@ def _lifecycle_donut_svg(coverage: int, r: int = 44) -> str:
     )
 
 
+def _make_test_report(
+    *,
+    current_score: int = 60,
+    reload_events: int = 0,
+    resume_events: int = 5,
+    score_week1_uplift: int | None = None,
+) -> "ImpactReport":
+    """Build a minimal ImpactReport for tests and dashboard snapshots."""
+    now = dt.datetime.now(dt.timezone.utc)
+    history = ImpactHistory(
+        first_seen=now.isoformat(),
+        latest_seen=now.isoformat(),
+        latest_score=current_score,
+        min_score=current_score,
+        max_score=current_score,
+        score_delta=0,
+        daily_event_counts=(),
+        score_series=(),
+        recent_events=(),
+    )
+    usability = UsabilityMetrics(
+        active_days=1,
+        resume_events=resume_events,
+        checkpoint_events=0,
+        reload_events=reload_events,
+        session_end_events=0,
+        lifecycle_coverage=25,
+        readiness_minutes_since_last_event=0,
+        avg_session_duration_minutes=None,
+        max_session_duration_minutes=None,
+        cold_start_time_saved_minutes=reload_events * 5,
+        score_week1_uplift=score_week1_uplift,
+    )
+    return ImpactReport(
+        repo_name="test-repo",
+        repo_id="test-repo",
+        telemetry_path=Path("/tmp/test-telemetry.jsonl"),
+        current_score=current_score,
+        estimated_baseline_score=20,
+        observed_events=resume_events + reload_events,
+        event_counts={},
+        dashboard_path=Path("/tmp/test-dashboard.html"),
+        history=history,
+        usability=usability,
+        recommendations=(),
+    )
+
+
 def render_monitoring_dashboard(
     report: ImpactReport,
     branch_stats: list[Any] | None = None,
@@ -730,6 +778,19 @@ def render_monitoring_dashboard(
     tokens_injected_str = f"{tokens_injected:,}"
     tokens_saved_str = f"{tokens_saved:,}"
     cost_saved_str = f"${cost_saved_usd:.2f}"
+
+    # cold-start time saved
+    cold_start_min = report.usability.cold_start_time_saved_minutes
+    cold_start_str = f"{cold_start_min} min" if cold_start_min > 0 else "—"
+
+    # week-1 score uplift
+    uplift = report.usability.score_week1_uplift
+    if uplift is None:
+        uplift_str = "—"
+    elif uplift >= 0:
+        uplift_str = f"+{uplift}"
+    else:
+        uplift_str = str(uplift)
 
     # lifecycle donut
     donut = _lifecycle_donut_svg(report.usability.lifecycle_coverage)
@@ -867,7 +928,7 @@ def render_monitoring_dashboard(
     }}
     .metric sub {{ font-size: 14px; opacity: .6; }}
     .savings-row {{
-      display: grid; grid-template-columns: repeat(3, minmax(0,1fr));
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
       gap: 14px; margin: 14px 0;
     }}
     .savings-card {{
@@ -994,6 +1055,16 @@ def render_monitoring_dashboard(
           <span>Est. cost saved</span>
           <strong>{cost_saved_str}</strong>
           <em>Claude Sonnet $3/M input tokens</em>
+        </div>
+        <div class="savings-card">
+          <span>Cold starts prevented (est.)</span>
+          <strong>{cold_start_str}</strong>
+          <em>Each context reload saves ~5 min re-orientation</em>
+        </div>
+        <div class="savings-card">
+          <span>Week-1 uplift</span>
+          <strong>{uplift_str}</strong>
+          <em>Score gain from day 0 to day 7</em>
         </div>
       </div>
 

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -1,0 +1,322 @@
+"""Tests for repo_context_hooks.consent module."""
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+import repo_context_hooks.consent as consent_mod
+
+
+@pytest.fixture(autouse=True)
+def _redirect_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect consent config to a temp path for every test."""
+    override_path = tmp_path / "consent.json"
+    monkeypatch.setattr(consent_mod, "_CONFIG_PATH_OVERRIDE", override_path)
+
+
+# ---------------------------------------------------------------------------
+# consent_config_path()
+# ---------------------------------------------------------------------------
+
+def test_consent_config_path_returns_path_under_platform_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without the override, path should end with consent.json inside a known dir."""
+    monkeypatch.setattr(consent_mod, "_CONFIG_PATH_OVERRIDE", None)
+
+    path = consent_mod.consent_config_path()
+    assert path.name == "consent.json"
+    assert "repo-context-hooks" in str(path)
+    # Must not be a raw home dir root - should be inside a config subdir
+    assert path != Path.home() / "consent.json"
+
+
+def test_consent_config_path_respects_override(tmp_path: Path) -> None:
+    """The _CONFIG_PATH_OVERRIDE fixture should redirect correctly."""
+    path = consent_mod.consent_config_path()
+    assert path == tmp_path / "consent.json"
+
+
+# ---------------------------------------------------------------------------
+# get_consent_state()
+# ---------------------------------------------------------------------------
+
+def test_get_consent_state_returns_not_set_when_no_config(tmp_path: Path) -> None:
+    state = consent_mod.get_consent_state()
+    assert state["status"] == "not_set"
+    assert state["enabled_at"] is None
+    assert state["install_id"] is None
+    assert "consent.json" in state["config_path"]
+
+
+def test_get_consent_state_reflects_enabled(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    state = consent_mod.get_consent_state()
+    assert state["status"] == "enabled"
+    assert state["install_id"] is not None
+    assert state["enabled_at"] is not None
+
+
+def test_get_consent_state_reflects_disabled(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    consent_mod.disable_consent()
+    state = consent_mod.get_consent_state()
+    assert state["status"] == "disabled"
+
+
+# ---------------------------------------------------------------------------
+# enable_consent()
+# ---------------------------------------------------------------------------
+
+def test_enable_consent_writes_config_and_returns_enabled_state(tmp_path: Path) -> None:
+    state = consent_mod.enable_consent()
+    assert state["status"] == "enabled"
+    assert state["install_id"] is not None
+    # install_id should be a valid UUID
+    uuid.UUID(state["install_id"])  # raises if invalid
+
+
+def test_enable_consent_creates_config_file(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    config_path = consent_mod.consent_config_path()
+    assert config_path.exists()
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["consented"] is True
+    assert "install_id" in data
+    assert "enabled_at" in data
+
+
+def test_enable_consent_preserves_existing_install_id(tmp_path: Path) -> None:
+    state1 = consent_mod.enable_consent()
+    id1 = state1["install_id"]
+    consent_mod.disable_consent()
+    state2 = consent_mod.enable_consent()
+    assert state2["install_id"] == id1
+
+
+# ---------------------------------------------------------------------------
+# disable_consent()
+# ---------------------------------------------------------------------------
+
+def test_disable_consent_returns_disabled_state(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    state = consent_mod.disable_consent()
+    assert state["status"] == "disabled"
+
+
+def test_disable_consent_creates_config_even_without_prior_enable(tmp_path: Path) -> None:
+    state = consent_mod.disable_consent()
+    assert state["status"] == "disabled"
+    assert consent_mod.consent_config_path().exists()
+
+
+def test_disable_consent_overwrites_enabled(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    consent_mod.disable_consent()
+    data = json.loads(consent_mod.consent_config_path().read_text(encoding="utf-8"))
+    assert data["consented"] is False
+
+
+# ---------------------------------------------------------------------------
+# is_consented()
+# ---------------------------------------------------------------------------
+
+def test_is_consented_false_when_not_set(tmp_path: Path) -> None:
+    assert consent_mod.is_consented() is False
+
+
+def test_is_consented_true_when_enabled(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    assert consent_mod.is_consented() is True
+
+
+def test_is_consented_false_when_disabled(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    consent_mod.disable_consent()
+    assert consent_mod.is_consented() is False
+
+
+# ---------------------------------------------------------------------------
+# preview_payload()
+# ---------------------------------------------------------------------------
+
+def test_preview_payload_returns_dict_with_required_keys(tmp_path: Path) -> None:
+    payload = consent_mod.preview_payload()
+    required = {
+        "install_id",
+        "package_version",
+        "platform_adapter",
+        "os_family",
+        "python_minor",
+        "continuity_score",
+        "estimated_baseline_score",
+        "lifecycle_event_counts",
+        "collector_endpoint",
+        "disclaimer",
+    }
+    assert required <= payload.keys()
+
+
+def test_preview_payload_contains_disclaimer(tmp_path: Path) -> None:
+    payload = consent_mod.preview_payload()
+    assert "No data has been sent" in payload["disclaimer"]
+
+
+def test_preview_payload_no_local_paths(tmp_path: Path) -> None:
+    """Payload must not contain any string that looks like an absolute local path."""
+    payload = consent_mod.preview_payload()
+    payload_str = json.dumps(payload)
+    # Should not contain Windows drive letters or Unix-style absolute paths
+    # beyond the known safe fields.
+    for key in ("install_id", "package_version", "platform_adapter", "os_family",
+                "python_minor", "collector_endpoint", "disclaimer"):
+        val = str(payload.get(key, ""))
+        # These fields should not contain path separators that imply local paths
+        assert "Users" not in val, f"Field {key!r} may contain a local path: {val!r}"
+        assert "home" not in val.lower() or key in ("os_family",), (
+            f"Field {key!r} may contain a local path reference: {val!r}"
+        )
+
+
+def test_preview_payload_install_id_placeholder_when_not_consented(tmp_path: Path) -> None:
+    payload = consent_mod.preview_payload()
+    assert payload["install_id"] == "not-yet-generated"
+
+
+def test_preview_payload_install_id_populated_after_enable(tmp_path: Path) -> None:
+    consent_mod.enable_consent()
+    payload = consent_mod.preview_payload()
+    assert payload["install_id"] != "not-yet-generated"
+    uuid.UUID(payload["install_id"])  # should be valid UUID
+
+
+def test_preview_payload_collector_endpoint_not_configured(tmp_path: Path) -> None:
+    payload = consent_mod.preview_payload()
+    assert payload["collector_endpoint"] == "not yet configured"
+
+
+def test_preview_payload_null_scores_without_repo_root(tmp_path: Path) -> None:
+    payload = consent_mod.preview_payload(repo_root=None)
+    assert payload["continuity_score"] is None
+    assert payload["estimated_baseline_score"] is None
+    assert payload["lifecycle_event_counts"] == {}
+
+
+def test_preview_payload_python_minor_format(tmp_path: Path) -> None:
+    import sys
+    payload = consent_mod.preview_payload()
+    expected = f"{sys.version_info.major}.{sys.version_info.minor}"
+    assert payload["python_minor"] == expected
+
+
+# ---------------------------------------------------------------------------
+# CLI integration - telemetry subcommand
+# ---------------------------------------------------------------------------
+
+def test_cli_telemetry_status_parseable(tmp_path: Path) -> None:
+    """build_parser() must accept 'telemetry status'."""
+    from repo_context_hooks.cli import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["telemetry", "status"])
+    assert args.command == "telemetry"
+    assert args.telemetry_subcommand == "status"
+
+
+def test_cli_telemetry_enable_parseable(tmp_path: Path) -> None:
+    from repo_context_hooks.cli import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["telemetry", "enable", "--yes"])
+    assert args.command == "telemetry"
+    assert args.telemetry_subcommand == "enable"
+    assert args.yes is True
+
+
+def test_cli_telemetry_disable_parseable(tmp_path: Path) -> None:
+    from repo_context_hooks.cli import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["telemetry", "disable"])
+    assert args.command == "telemetry"
+    assert args.telemetry_subcommand == "disable"
+
+
+def test_cli_telemetry_preview_parseable(tmp_path: Path) -> None:
+    from repo_context_hooks.cli import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["telemetry", "preview"])
+    assert args.command == "telemetry"
+    assert args.telemetry_subcommand == "preview"
+
+
+def test_cli_telemetry_status_not_configured_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    from repo_context_hooks.cli import _telemetry_cmd
+    from argparse import Namespace
+    args = Namespace(command="telemetry", telemetry_subcommand="status")
+    ret = _telemetry_cmd(args)
+    assert ret == 0
+    out = capsys.readouterr().out
+    assert "not configured" in out
+    assert "will be generated on first enable" in out
+
+
+def test_cli_telemetry_enable_yes_flag(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    from repo_context_hooks.cli import _telemetry_cmd
+    from argparse import Namespace
+    args = Namespace(command="telemetry", telemetry_subcommand="enable", yes=True)
+    ret = _telemetry_cmd(args)
+    assert ret == 0
+    out = capsys.readouterr().out
+    assert "enabled" in out
+    assert "No data is being sent" in out
+
+
+def test_cli_telemetry_enable_noninteractive_without_yes(
+    tmp_path: Path, capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In a non-interactive environment (EOF on stdin), should print graceful message."""
+    from repo_context_hooks.cli import _telemetry_cmd
+    from argparse import Namespace
+
+    def _raise_eof(_prompt: str) -> str:
+        raise EOFError
+
+    # Simulate EOF on stdin
+    monkeypatch.setattr("builtins.input", _raise_eof)
+    args = Namespace(command="telemetry", telemetry_subcommand="enable", yes=False)
+    ret = _telemetry_cmd(args)
+    assert ret == 0
+    out = capsys.readouterr().out
+    assert "Telemetry remains disabled" in out
+
+
+def test_cli_telemetry_disable_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    from repo_context_hooks.cli import _telemetry_cmd
+    from argparse import Namespace
+    args = Namespace(command="telemetry", telemetry_subcommand="disable")
+    ret = _telemetry_cmd(args)
+    assert ret == 0
+    out = capsys.readouterr().out
+    assert "disabled" in out
+
+
+def test_cli_telemetry_preview_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    from repo_context_hooks.cli import _telemetry_cmd
+    from argparse import Namespace
+    args = Namespace(command="telemetry", telemetry_subcommand="preview", repo_root=None)
+    ret = _telemetry_cmd(args)
+    assert ret == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert "disclaimer" in data
+    assert "No data has been sent" in data["disclaimer"]
+    assert data["collector_endpoint"] == "not yet configured"

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,443 @@
+"""Tests for measure experiment start / finish / status commands."""
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from repo_context_hooks.cli import _measure
+from repo_context_hooks.repo_contract import init_repo_contract
+from repo_context_hooks.telemetry import (
+    experiment_finish,
+    experiment_start,
+    experiment_status,
+    measure_impact,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _tmp_dir() -> Path:
+    base = ROOT / ".tmp-tests"
+    base.mkdir(exist_ok=True)
+    path = base / uuid4().hex
+    path.mkdir()
+    return path
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_contract(repo)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# experiment_start
+# ---------------------------------------------------------------------------
+
+
+def test_experiment_start_creates_before_json(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    before_path = experiment_start(repo, exp_dir)
+
+    assert before_path == exp_dir / "before.json"
+    assert before_path.exists()
+    data = json.loads(before_path.read_text(encoding="utf-8"))
+    for key in ("timestamp", "score", "baseline", "uplift", "observed_events",
+                "event_counts", "lifecycle_coverage", "contract_files_present"):
+        assert key in data, f"Missing key: {key}"
+
+
+def test_experiment_start_creates_experiment_dir(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "nonexistent" / "subdir"
+
+    experiment_start(repo, exp_dir)
+
+    assert exp_dir.exists()
+
+
+def test_experiment_start_contract_files_present_is_dict_of_bools(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+
+    data = json.loads((exp_dir / "before.json").read_text(encoding="utf-8"))
+    cfp = data["contract_files_present"]
+    assert isinstance(cfp, dict)
+    assert all(isinstance(v, bool) for v in cfp.values())
+
+
+def test_experiment_start_fails_if_before_json_already_exists(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+
+    with pytest.raises(FileExistsError, match="experiment is already in progress"):
+        experiment_start(repo, exp_dir)
+
+
+def test_experiment_start_prints_guidance(tmp_path: Path, capsys) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+
+    out = capsys.readouterr().out
+    assert "experiment finish" in out
+
+
+# ---------------------------------------------------------------------------
+# experiment_finish
+# ---------------------------------------------------------------------------
+
+
+def test_experiment_finish_creates_after_json(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+    result = experiment_finish(repo, exp_dir)
+
+    after_path = exp_dir / "after.json"
+    assert after_path.exists()
+    data = json.loads(after_path.read_text(encoding="utf-8"))
+    for key in ("timestamp", "score", "baseline", "uplift", "observed_events",
+                "event_counts", "lifecycle_coverage", "contract_files_present"):
+        assert key in data, f"Missing key: {key}"
+
+
+def test_experiment_finish_returns_comparison_dict(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+    result = experiment_finish(repo, exp_dir)
+
+    for key in ("before", "after", "score_delta", "uplift_delta", "events_delta", "new_files", "summary"):
+        assert key in result, f"Missing key: {key}"
+    assert isinstance(result["score_delta"], int)
+    assert isinstance(result["new_files"], list)
+    assert isinstance(result["summary"], str)
+
+
+def test_experiment_finish_fails_if_before_json_missing(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+    exp_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="experiment start"):
+        experiment_finish(repo, exp_dir)
+
+
+def test_experiment_finish_score_delta_is_correct(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+    result = experiment_finish(repo, exp_dir)
+
+    before_score = result["before"]["score"]
+    after_score = result["after"]["score"]
+    assert result["score_delta"] == after_score - before_score
+
+
+def test_experiment_finish_new_files_detects_additions(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    # Start before any extra files
+    experiment_start(repo, exp_dir)
+
+    # CLAUDE.md is tracked by contract_signals but not created by init_repo_contract
+    claude_file = repo / "CLAUDE.md"
+    claude_file.write_text("# Project instructions\n", encoding="utf-8")
+
+    result = experiment_finish(repo, exp_dir)
+
+    assert "CLAUDE.md" in result["new_files"]
+
+
+def test_experiment_finish_summary_never_says_productivity(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+    result = experiment_finish(repo, exp_dir)
+
+    assert "productivity" not in result["summary"].lower(), (
+        "Claim boundary violation: summary must not mention 'productivity'"
+    )
+
+
+def test_experiment_finish_summary_mentions_continuity_or_contract(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+    result = experiment_finish(repo, exp_dir)
+
+    summary_lower = result["summary"].lower()
+    assert "continuity" in summary_lower or "contract" in summary_lower, (
+        "Summary should use 'continuity' or 'contract' terminology"
+    )
+
+
+# ---------------------------------------------------------------------------
+# experiment_status
+# ---------------------------------------------------------------------------
+
+
+def test_experiment_status_not_started(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "experiment"
+    exp_dir.mkdir()
+
+    status = experiment_status(exp_dir)
+
+    assert status["state"] == "not_started"
+    assert "experiment start" in status["message"]
+
+
+def test_experiment_status_in_progress(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+    status = experiment_status(exp_dir)
+
+    assert status["state"] == "in_progress"
+    assert "in progress" in status["message"].lower()
+
+
+def test_experiment_status_finished(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "experiment"
+
+    experiment_start(repo, exp_dir)
+    experiment_finish(repo, exp_dir)
+    status = experiment_status(exp_dir)
+
+    assert status["state"] == "finished"
+    assert "complete" in status["message"].lower()
+
+
+def test_experiment_status_nonexistent_dir(tmp_path: Path) -> None:
+    exp_dir = tmp_path / "does-not-exist"
+
+    status = experiment_status(exp_dir)
+
+    assert status["state"] == "not_started"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: _measure() dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cli_measure_experiment_start(tmp_path: Path, capsys) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "exp"
+
+    args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "start"],
+        experiment_dir=str(exp_dir),
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    rc = _measure(args)
+
+    assert rc == 0
+    assert (exp_dir / "before.json").exists()
+    out = capsys.readouterr().out
+    assert "before.json" in out.lower() or "experiment" in out.lower()
+
+
+def test_cli_measure_experiment_finish(tmp_path: Path, capsys) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "exp"
+
+    # start first
+    start_args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "start"],
+        experiment_dir=str(exp_dir),
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    assert _measure(start_args) == 0
+    capsys.readouterr()
+
+    finish_args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "finish"],
+        experiment_dir=str(exp_dir),
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    rc = _measure(finish_args)
+
+    assert rc == 0
+    assert (exp_dir / "after.json").exists()
+    out = capsys.readouterr().out
+    assert "complete" in out.lower() or "after" in out.lower()
+
+
+def test_cli_measure_experiment_status(tmp_path: Path, capsys) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "exp"
+
+    args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "status"],
+        experiment_dir=str(exp_dir),
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    rc = _measure(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "experiment start" in out
+
+
+def test_cli_measure_experiment_start_fails_gracefully_when_already_exists(
+    tmp_path: Path, capsys
+) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "exp"
+
+    args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "start"],
+        experiment_dir=str(exp_dir),
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    assert _measure(args) == 0
+    capsys.readouterr()
+
+    rc = _measure(args)
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Error" in out or "already" in out.lower()
+
+
+def test_cli_measure_experiment_finish_fails_gracefully_with_no_start(
+    tmp_path: Path, capsys
+) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "exp"
+
+    args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "finish"],
+        experiment_dir=str(exp_dir),
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    rc = _measure(args)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Error" in out or "experiment start" in out
+
+
+def test_cli_measure_experiment_unknown_subcommand(tmp_path: Path, capsys) -> None:
+    repo = _make_repo(tmp_path)
+    exp_dir = tmp_path / "exp"
+
+    args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "banana"],
+        experiment_dir=str(exp_dir),
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    rc = _measure(args)
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Unknown" in out or "banana" in out
+
+
+def test_cli_measure_experiment_default_dir_uses_repo_root(tmp_path: Path, capsys) -> None:
+    """When --experiment-dir is not given, default should be <repo_root>/.repo-context-hooks/experiment."""
+    repo = _make_repo(tmp_path)
+
+    args = Namespace(
+        repo_root=str(repo),
+        positional_args=["experiment", "start"],
+        experiment_dir=None,
+        clean_ghosts=False,
+        forecast=False,
+        branches=False,
+        json=False,
+        badge=False,
+        badge_out=None,
+        snapshot_dir=None,
+        open=False,
+        dry_run=True,
+    )
+    rc = _measure(args)
+
+    assert rc == 0
+    assert (repo / ".repo-context-hooks" / "experiment" / "before.json").exists()
+    capsys.readouterr()

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,260 @@
+"""Tests for export_impact_report() and the 'measure export' CLI subcommand."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+from repo_context_hooks.telemetry import _make_test_report, export_impact_report
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tmp_dir() -> Path:
+    base = ROOT / ".tmp-tests"
+    base.mkdir(exist_ok=True)
+    path = base / uuid4().hex
+    path.mkdir()
+    return path
+
+
+def _report_with_events():
+    """Return a test report that has non-empty event_counts and history."""
+    from repo_context_hooks.repo_contract import init_repo_contract
+    from repo_context_hooks.telemetry import measure_impact, record_event
+
+    tmp = _tmp_dir()
+    repo = tmp / "myproject"
+    repo.mkdir()
+    init_repo_contract(repo)
+    tbase = tmp / "telem"
+    record_event(repo, "session-start", telemetry_base=tbase)
+    record_event(repo, "post-compact", telemetry_base=tbase)
+    return measure_impact(repo, telemetry_base=tbase)
+
+
+# ---------------------------------------------------------------------------
+# JSON format tests
+# ---------------------------------------------------------------------------
+
+
+def test_export_json_is_valid_json():
+    report = _make_test_report()
+    output = export_impact_report(report, format="json")
+    parsed = json.loads(output)  # must not raise
+    assert isinstance(parsed, dict)
+
+
+def test_export_json_has_required_keys():
+    report = _make_test_report(current_score=90)
+    parsed = json.loads(export_impact_report(report, format="json"))
+    assert "repo" in parsed
+    assert "score" in parsed
+    assert "uplift" in parsed
+    assert "disclaimer" in parsed
+    assert "generated_at" in parsed
+    assert "baseline" in parsed
+    assert "observed_events" in parsed
+
+
+def test_export_json_values_are_correct():
+    report = _make_test_report(current_score=90)
+    parsed = json.loads(export_impact_report(report, format="json"))
+    assert parsed["repo"] == "test-repo"
+    assert parsed["score"] == 90
+    assert parsed["baseline"] == 20
+    assert parsed["uplift"] == 70
+
+
+def test_export_json_has_no_local_filesystem_paths():
+    """The JSON output must not contain the telemetry_path or dashboard_path."""
+    report = _make_test_report()
+    output = export_impact_report(report, format="json")
+    # Verify local paths are absent - check for path separators typical of absolute paths
+    assert str(report.telemetry_path) not in output
+    assert str(report.dashboard_path) not in output
+    # No Windows-style absolute path fragments (e.g. "C:\\", "C:/")
+    assert "C:\\" not in output
+    assert "C:/" not in output
+    assert "/tmp/test-telemetry" not in output
+    assert "/tmp/test-dashboard" not in output
+
+
+def test_export_json_no_repo_id():
+    """repo_id (the hash) should not appear in the JSON output."""
+    report = _make_test_report()
+    parsed = json.loads(export_impact_report(report, format="json"))
+    assert "repo_id" not in parsed
+
+
+def test_export_json_usability_metrics_present():
+    report = _make_test_report(current_score=80, reload_events=3, resume_events=7)
+    parsed = json.loads(export_impact_report(report, format="json"))
+    assert parsed["resume_events"] == 7
+    assert parsed["reload_events"] == 3
+    assert parsed["cold_start_time_saved_minutes"] == 15  # 3 * 5
+    assert parsed["active_days"] == 1
+    assert parsed["lifecycle_coverage_pct"] == 25
+
+
+def test_export_json_date_only_timestamps():
+    """first_seen and latest_seen must be dates (10 chars), not full ISO strings."""
+    report = _make_test_report()
+    parsed = json.loads(export_impact_report(report, format="json"))
+    first = parsed.get("first_seen")
+    latest = parsed.get("latest_seen")
+    if first is not None:
+        assert len(first) == 10, f"Expected date-only, got: {first!r}"
+    if latest is not None:
+        assert len(latest) == 10, f"Expected date-only, got: {latest!r}"
+
+
+def test_export_json_with_real_events_no_paths():
+    """Integration: export from a real measure_impact call must have no local paths."""
+    report = _report_with_events()
+    output = export_impact_report(report, format="json")
+    parsed = json.loads(output)
+    # No absolute path strings in keys or values
+    serialised = json.dumps(parsed)
+    assert str(report.telemetry_path) not in serialised
+    assert str(report.dashboard_path) not in serialised
+
+
+# ---------------------------------------------------------------------------
+# Markdown format tests
+# ---------------------------------------------------------------------------
+
+
+def test_export_markdown_has_h2_heading():
+    report = _make_test_report()
+    output = export_impact_report(report, format="markdown")
+    assert output.startswith("## ")
+
+
+def test_export_markdown_has_table():
+    report = _make_test_report()
+    output = export_impact_report(report, format="markdown")
+    assert "| Metric | Value |" in output
+    assert "|---|---|" in output
+
+
+def test_export_markdown_shows_score_and_uplift():
+    report = _make_test_report(current_score=85)
+    output = export_impact_report(report, format="markdown")
+    assert "85" in output
+    assert "+65" in output  # uplift = 85 - 20
+
+
+def test_export_markdown_has_disclaimer():
+    report = _make_test_report()
+    output = export_impact_report(report, format="markdown")
+    assert "local operational telemetry" in output
+    assert "no source code" in output
+
+
+def test_export_markdown_has_no_local_filesystem_paths():
+    report = _make_test_report()
+    output = export_impact_report(report, format="markdown")
+    assert str(report.telemetry_path) not in output
+    assert str(report.dashboard_path) not in output
+    assert "/tmp/test-telemetry" not in output
+    assert "/tmp/test-dashboard" not in output
+
+
+def test_export_markdown_includes_event_breakdown_when_nonempty():
+    report = _report_with_events()
+    output = export_impact_report(report, format="markdown")
+    assert "Event breakdown" in output
+    assert "session-start" in output
+
+
+def test_export_markdown_no_event_breakdown_when_empty():
+    report = _make_test_report()  # event_counts={}
+    output = export_impact_report(report, format="markdown")
+    assert "Event breakdown" not in output
+
+
+# ---------------------------------------------------------------------------
+# Redact flag behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_export_redact_default_is_true():
+    """Calling export without redact= should still produce clean output."""
+    report = _make_test_report()
+    output = export_impact_report(report)
+    assert str(report.telemetry_path) not in output
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "repo_context_hooks", *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd or ROOT),
+    )
+
+
+def test_cli_measure_export_markdown_exits_zero():
+    result = _run_cli("measure", "export", "--format", "markdown")
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_measure_export_json_exits_zero():
+    result = _run_cli("measure", "export", "--format", "json")
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_measure_export_json_is_valid_json():
+    result = _run_cli("measure", "export", "--format", "json")
+    assert result.returncode == 0
+    parsed = json.loads(result.stdout)
+    assert "score" in parsed
+    assert "uplift" in parsed
+    assert "disclaimer" in parsed
+
+
+def test_cli_measure_export_markdown_has_heading():
+    result = _run_cli("measure", "export", "--format", "markdown")
+    assert result.returncode == 0
+    assert "## " in result.stdout
+
+
+def test_cli_measure_export_to_file(tmp_path):
+    out_file = tmp_path / "report.md"
+    result = _run_cli("measure", "export", "--format", "markdown", "--output", str(out_file))
+    assert result.returncode == 0
+    assert out_file.exists()
+    content = out_file.read_text(encoding="utf-8")
+    assert "## " in content
+    assert "Export written to:" in result.stdout
+
+
+def test_cli_measure_export_json_no_local_paths():
+    """The CLI JSON export must contain no local user path fragments."""
+    result = _run_cli("measure", "export", "--format", "json")
+    assert result.returncode == 0
+    # Should not contain typical absolute path markers
+    assert "C:\\" not in result.stdout
+    assert "\\Users\\" not in result.stdout
+    assert "/home/" not in result.stdout
+
+
+def test_cli_measure_existing_flags_still_work():
+    """Ensure existing measure flags are not broken by the new subcommand."""
+    result = _run_cli("measure", "--json")
+    assert result.returncode == 0
+    parsed = json.loads(result.stdout)
+    assert "current_score" in parsed

--- a/tests/test_monitoring_surface.py
+++ b/tests/test_monitoring_surface.py
@@ -77,3 +77,30 @@ def test_svg_brand_logo_source_carries_product_language() -> None:
     ]
     for snippet in required:
         assert snippet in text
+
+
+def test_dashboard_contains_cold_start_card():
+    """Dashboard HTML must show the cold start time saved metric."""
+    from repo_context_hooks.telemetry import render_monitoring_dashboard, _make_test_report
+    report = _make_test_report(reload_events=3)  # 3 * 5 = 15 min
+    html = render_monitoring_dashboard(report)
+    assert "Cold starts prevented" in html
+    assert "15 min" in html
+
+
+def test_dashboard_contains_week1_uplift_card():
+    """Dashboard HTML must show the week-1 score uplift when data is available."""
+    from repo_context_hooks.telemetry import render_monitoring_dashboard, _make_test_report
+    report = _make_test_report(score_week1_uplift=25)
+    html = render_monitoring_dashboard(report)
+    assert "Week-1 uplift" in html
+    assert "+25" in html
+
+
+def test_dashboard_uplift_dash_when_none():
+    """Dashboard must show — when score_week1_uplift is None."""
+    from repo_context_hooks.telemetry import render_monitoring_dashboard, _make_test_report
+    report = _make_test_report(score_week1_uplift=None)
+    html = render_monitoring_dashboard(report)
+    assert "Week-1 uplift" in html
+    assert "—" in html  # em-dash rendered when uplift is None

--- a/tests/test_roi_metrics.py
+++ b/tests/test_roi_metrics.py
@@ -1,0 +1,102 @@
+"""Tests for ROI metrics: cold_start_time_saved_minutes and score_week1_uplift."""
+import datetime as dt
+from repo_context_hooks.telemetry import _build_usability, ImpactHistory
+
+
+def _make_history(score_series=None, daily_event_counts=None):
+    now = dt.datetime.now(dt.timezone.utc)
+    score_series = score_series or [{"date": now.strftime("%Y-%m-%d"), "score": 60}]
+    daily = daily_event_counts or [{"date": now.strftime("%Y-%m-%d"), "events": 3}]
+    return ImpactHistory(
+        first_seen=(now - dt.timedelta(days=10)).isoformat(),
+        latest_seen=now.isoformat(),
+        latest_score=score_series[-1]["score"],
+        min_score=min(s["score"] for s in score_series),
+        max_score=max(s["score"] for s in score_series),
+        score_delta=score_series[-1]["score"] - score_series[0]["score"],
+        daily_event_counts=tuple(daily),
+        score_series=tuple(score_series),
+        recent_events=(),
+    )
+
+
+def test_cold_start_time_saved_is_reload_events_times_5():
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60},
+        {"event_name": "post-compact", "timestamp": "2026-04-20T10:30:00+00:00", "repo_contract_score": 60},
+        {"event_name": "post-compact", "timestamp": "2026-04-21T09:00:00+00:00", "repo_contract_score": 65},
+    ]
+    history = _make_history()
+    metrics = _build_usability(events, history)
+    assert metrics.cold_start_time_saved_minutes == 10  # 2 reloads * 5 min
+
+
+def test_cold_start_zero_when_no_reloads():
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60},
+    ]
+    history = _make_history()
+    metrics = _build_usability(events, history)
+    assert metrics.cold_start_time_saved_minutes == 0
+
+
+def test_score_week1_uplift_computes_correctly():
+    base = dt.date(2026, 4, 10)
+    score_series = [
+        {"date": (base + dt.timedelta(days=i)).isoformat(), "score": 40 + i * 5}
+        for i in range(14)
+    ]
+    history = _make_history(score_series=score_series)
+    events = [
+        {
+            "event_name": "session-start",
+            "timestamp": f"{s['date']}T10:00:00+00:00",
+            "repo_contract_score": s["score"],
+        }
+        for s in score_series
+    ]
+    metrics = _build_usability(events, history)
+    # day 0 = score 40, day 7 = score 40 + 7*5 = 75, uplift = 35
+    assert metrics.score_week1_uplift == 35
+
+
+def test_score_week1_uplift_none_when_fewer_than_2_days():
+    score_series = [{"date": "2026-04-20", "score": 60}]
+    history = _make_history(score_series=score_series)
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60}
+    ]
+    metrics = _build_usability(events, history)
+    assert metrics.score_week1_uplift is None
+
+
+def test_score_week1_uplift_none_when_no_day7_data():
+    """If there are only 3 days of data (all within week 1), uplift is None."""
+    base = dt.date(2026, 4, 10)
+    score_series = [
+        {"date": (base + dt.timedelta(days=i)).isoformat(), "score": 50 + i * 3}
+        for i in range(3)  # days 0, 1, 2 — no day 7
+    ]
+    history = _make_history(score_series=score_series)
+    events = [
+        {
+            "event_name": "session-start",
+            "timestamp": f"{s['date']}T10:00:00+00:00",
+            "repo_contract_score": s["score"],
+        }
+        for s in score_series
+    ]
+    metrics = _build_usability(events, history)
+    assert metrics.score_week1_uplift is None
+
+
+def test_roi_metrics_in_to_dict():
+    """Both new fields must appear in to_dict() output."""
+    events = [
+        {"event_name": "session-start", "timestamp": "2026-04-20T10:00:00+00:00", "repo_contract_score": 60},
+        {"event_name": "post-compact", "timestamp": "2026-04-20T10:30:00+00:00", "repo_contract_score": 60},
+    ]
+    history = _make_history()
+    d = _build_usability(events, history).to_dict()
+    assert "cold_start_time_saved_minutes" in d
+    assert "score_week1_uplift" in d

--- a/tests/test_session_duration_wiring.py
+++ b/tests/test_session_duration_wiring.py
@@ -1,0 +1,83 @@
+"""Tests that bundle/scripts/repo_specs_memory.py wires session duration tracking."""
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _load_dev_script_record_telemetry():
+    """Return the record_telemetry function from bundle/scripts/repo_specs_memory.py."""
+    script = (
+        Path(__file__).parent.parent
+        / "repo_context_hooks"
+        / "bundle"
+        / "scripts"
+        / "repo_specs_memory.py"
+    )
+    spec = importlib.util.spec_from_file_location("rsmdev", script)
+    mod = importlib.util.module_from_spec(spec)
+    # The script reads a module-level EVENT variable — patch it before exec
+    return mod, spec
+
+
+def test_dev_script_calls_record_session_start_time(tmp_path, monkeypatch):
+    """record_telemetry must call record_session_start_time when EVENT='session-start'."""
+    monkeypatch.setenv("EVENT", "session-start")
+    called = []
+
+    mock_telemetry = MagicMock()
+    mock_telemetry.record_session_start_time.side_effect = lambda r: called.append(r)
+    mock_telemetry.record_event.return_value = tmp_path / "events.jsonl"
+
+    mod, spec = _load_dev_script_record_telemetry()
+    sys.modules["repo_context_hooks.telemetry"] = mock_telemetry
+    try:
+        spec.loader.exec_module(mod)
+        mod.record_telemetry(tmp_path, tmp_path / "specs/README.md", tmp_path / "UL.md")
+    finally:
+        del sys.modules["repo_context_hooks.telemetry"]
+
+    assert len(called) == 1, "record_session_start_time must be called once on session-start"
+
+
+def test_dev_script_passes_duration_on_session_end(tmp_path, monkeypatch):
+    """record_telemetry must pass duration_minutes to record_event when EVENT='session-end'."""
+    monkeypatch.setenv("EVENT", "session-end")
+    captured_kwargs = []
+
+    mock_telemetry = MagicMock()
+    mock_telemetry.read_session_duration_minutes.return_value = 42
+    mock_telemetry.record_event.side_effect = lambda *a, **kw: captured_kwargs.append(kw) or (tmp_path / "events.jsonl")
+
+    mod, spec = _load_dev_script_record_telemetry()
+    sys.modules["repo_context_hooks.telemetry"] = mock_telemetry
+    try:
+        spec.loader.exec_module(mod)
+        mod.record_telemetry(tmp_path, tmp_path / "specs/README.md", tmp_path / "UL.md")
+    finally:
+        del sys.modules["repo_context_hooks.telemetry"]
+
+    assert any(kw.get("duration_minutes") == 42 for kw in captured_kwargs), (
+        f"record_event must receive duration_minutes=42, got: {captured_kwargs}"
+    )
+
+
+def test_dev_script_no_duration_on_session_start(tmp_path, monkeypatch):
+    """record_event must NOT receive duration_minutes on session-start."""
+    monkeypatch.setenv("EVENT", "session-start")
+    captured_kwargs = []
+
+    mock_telemetry = MagicMock()
+    mock_telemetry.record_event.side_effect = lambda *a, **kw: captured_kwargs.append(kw) or (tmp_path / "events.jsonl")
+    mock_telemetry.record_session_start_time.return_value = None
+
+    mod, spec = _load_dev_script_record_telemetry()
+    sys.modules["repo_context_hooks.telemetry"] = mock_telemetry
+    try:
+        spec.loader.exec_module(mod)
+        mod.record_telemetry(tmp_path, tmp_path / "specs/README.md", tmp_path / "UL.md")
+    finally:
+        del sys.modules["repo_context_hooks.telemetry"]
+
+    for kw in captured_kwargs:
+        assert kw.get("duration_minutes") is None, "duration_minutes must be None on session-start"

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -159,7 +159,8 @@ def test_is_sampled_reads_existing_decision_file(monkeypatch) -> None:
     session_dir = _session_state_dir(tmp)
     (session_dir / "current-session-sampled").write_text("true", encoding="utf-8")
 
-    result = is_sampled(tmp)
+    # Use rate=0.5 so the cache file is consulted (deterministic rates bypass it)
+    result = is_sampled(tmp, rate=0.5)
 
     assert result is True
 
@@ -171,7 +172,10 @@ def test_is_sampled_false_decision_file_returns_false(monkeypatch) -> None:
     session_dir = _session_state_dir(tmp)
     (session_dir / "current-session-sampled").write_text("false", encoding="utf-8")
 
-    result = is_sampled(tmp)
+    # Use rate=0.5 so the cache file is consulted (deterministic rates bypass it).
+    # NOTE: rate=1.0 intentionally ignores a cached "false" — that was the bug that
+    # caused 25% lifecycle coverage.  See test_rate_1_ignores_stale_false_cache.
+    result = is_sampled(tmp, rate=0.5)
 
     assert result is False
 

--- a/tests/test_telemetry_sampling_regression.py
+++ b/tests/test_telemetry_sampling_regression.py
@@ -112,6 +112,10 @@ def test_worktree_isolation_independent_sampling_decisions(tmp_path, monkeypatch
 
     If worktrees ever share a state dir accidentally, one worktree's sampled=false
     could suppress another worktree's events.
+
+    Uses rate=0.5 (a non-deterministic rate that reads the file cache) to exercise the
+    isolation property. rate=1.0 and rate=0.0 bypass the cache by design — see
+    test_rate_1_ignores_stale_false_cache / test_rate_0_ignores_stale_true_cache.
     """
     monkeypatch.delenv("REPO_CONTEXT_HOOKS_TELEMETRY", raising=False)
     monkeypatch.delenv("REPO_CONTEXT_HOOKS_SAMPLE_RATE", raising=False)
@@ -131,8 +135,29 @@ def test_worktree_isolation_independent_sampling_decisions(tmp_path, monkeypatch
     (state_a / "current-session-sampled").write_text("true", encoding="utf-8")
     (state_b / "current-session-sampled").write_text("false", encoding="utf-8")
 
-    assert is_sampled(repo_a) is True, "repo_a must be sampled"
-    assert is_sampled(repo_b) is False, "repo_b must not be sampled"
+    # Use rate=0.5 so the cache file is consulted (deterministic rates bypass it)
+    assert is_sampled(repo_a, rate=0.5) is True, "repo_a must be sampled"
+    assert is_sampled(repo_b, rate=0.5) is False, "repo_b must not be sampled"
 
     # repo_a's is_sampled call must not mutate repo_b's state
     assert (state_b / "current-session-sampled").read_text(encoding="utf-8").strip() == "false"
+
+
+def test_rate_1_ignores_stale_false_cache(tmp_path):
+    """rate=1.0 must always return True even if the cache file contains 'false'."""
+    from repo_context_hooks.telemetry import is_sampled, _session_state_dir, _SESSION_SAMPLED_FILE
+    state_dir = _session_state_dir(tmp_path)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / _SESSION_SAMPLED_FILE).write_text("false", encoding="utf-8")
+    for _ in range(100):
+        assert is_sampled(tmp_path, rate=1.0) is True
+
+
+def test_rate_0_ignores_stale_true_cache(tmp_path):
+    """rate=0.0 must always return False even if the cache file contains 'true'."""
+    from repo_context_hooks.telemetry import is_sampled, _session_state_dir, _SESSION_SAMPLED_FILE
+    state_dir = _session_state_dir(tmp_path)
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / _SESSION_SAMPLED_FILE).write_text("true", encoding="utf-8")
+    for _ in range(100):
+        assert is_sampled(tmp_path, rate=0.0) is False


### PR DESCRIPTION
## Summary

- **#24** `measure export --format markdown|json` - redacted shareable impact report with no local paths; paste directly into a README or LinkedIn post
- **#23** `measure experiment start/finish/status` - guided before/after continuity experiment that snapshots state, then diffs score/files/events with a plain-English summary (claim boundary enforced: no "productivity" language)
- **#26** `telemetry status|enable|disable|preview` - local consent infrastructure with platform-aware config file, `--yes` for CI use, and a payload preview that shows exactly what would be sent; no data actually leaves the machine yet

## Test plan

- [ ] `python -m pytest tests/test_export.py tests/test_experiment.py tests/test_consent.py -q` (77 new tests, all pass)
- [ ] `python -m pytest tests/ -q` (330 total, all pass)
- [ ] `repo-context-hooks measure export --format json` returns clean JSON with score/uplift/disclaimer, no filesystem paths
- [ ] `repo-context-hooks measure export --format markdown` returns README-pasteable table
- [ ] `repo-context-hooks measure experiment start && repo-context-hooks measure experiment status && repo-context-hooks measure experiment finish`
- [ ] `repo-context-hooks telemetry status` shows "not configured" when clean; `telemetry enable --yes` generates UUID install_id; `telemetry preview` shows no local paths
- [ ] `telemetry status` after enable shows "Note: Remote collector endpoint not yet configured. No data is being sent."

Closes #24, #23, #26

🤖 Generated with [Claude Code](https://claude.ai/claude-code)