### PR TITLE
chore: supply-chain hardening (CodeQL + Sigstore)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 4 * * 0'  # Sunday 04:00 UTC
+
+permissions:
+  security-events: write
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,8 @@ on:
       - "v*"
 
 permissions:
-  id-token: write  # required for PyPI Trusted Publisher (OIDC)
+  id-token: write    # required for PyPI Trusted Publisher (OIDC) and Sigstore
+  attestations: write  # required for gh-action-sigstore-python and PEP 740 provenance
 
 jobs:
   build:
@@ -25,6 +26,11 @@ jobs:
 
       - name: Build wheel and sdist
         run: python -m build
+
+      - name: Sign distributions with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: ./dist/*.whl ./dist/*.tar.gz
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
@@ -72,3 +78,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ repo-context-hooks install --platform claude
 
 That's the full install. Hooks write to `~/.claude/settings.json` and activate in every workspace from that point on.
 
+## Verify release integrity
+
+```bash
+gh attestation verify repo-context-hooks-X.Y.Z-py3-none-any.whl --repo narendranathe/repo-context-hooks
+```
+
 Need per-repo hooks too?
 
 ```bash


### PR DESCRIPTION
## What was added

- **`.github/workflows/codeql.yml`** — Python CodeQL scan triggered on push to `main`, pull requests, and weekly (Sunday 04:00 UTC). Uses `github/codeql-action` init/autobuild/analyze at `@v3` with minimal permissions (`security-events: write`, `actions: read`, `contents: read`).

- **`.github/workflows/publish.yml`** — Two changes:
  1. `sigstore/gh-action-sigstore-python@v3.0.0` step inserted after `python -m build` and before `upload-artifact` — signs the wheel and sdist, anchoring them to the Rekor transparency log.
  2. `attestations: true` added to the `pypa/gh-action-pypi-publish` step (PyPI only, not TestPyPI) — generates PEP 740 build provenance via GitHub's attestation store.
  3. `attestations: write` added to the workflow permissions block.

- **`README.md`** — `## Verify release integrity` snippet added under Install section:
  ```bash
  gh attestation verify repo-context-hooks-X.Y.Z-py3-none-any.whl --repo narendranathe/repo-context-hooks
  ```
  This verifies PEP 740 provenance (GitHub attestation store). The `.sigstore` bundles from the Sigstore signing step can additionally be verified via `cosign verify-blob`.

## What was already done

- **Dependabot config** (`dependabot.yml`) was merged in **PR #79** — excluded from this PR per task instructions.

## Self-review

### 5-critic verdict

| Critic | Verdict |
|--------|---------|
| A (Production Quality) | Pass — cron syntax correct, Sigstore placed correctly, OIDC flow intact. Nit: consider SHA-pinning sigstore action. |
| B (Acceptance Criteria) | All pre-merge ACs **Fully met**. Post-merge ACs (CodeQL green run, Dependabot PR) excluded. |
| C (Codebase Consistency) | Consistent with existing workflows. Nit: `ci.yml` lacks permissions block (pre-existing, out of scope). |
| D (Security) | Pass — minimal permissions, no hardcoded secrets, `attestations: true` on PyPI only. |
| E (Supply Chain Expert) | Pass — PEP 740 provenance correct, `gh attestation verify` command valid. Nit: `pypa/gh-action-pypi-publish@release/v1` is mutable (pre-existing tag, separate hardening PR). |

### Nits (not blocking)
- `pypa/gh-action-pypi-publish@release/v1` is a mutable floating tag — pre-existing in the workflow, SHA-pinning tracked separately
- `sigstore/gh-action-sigstore-python@v3.0.0` is semver-pinned but not SHA-pinned — low risk for a specific release tag
- The two signing mechanisms (`.sigstore` bundles + PEP 740 attestations) are additive, not redundant — both are valid verification paths

## Test results

```
330 passed in 18.40s
codeql.yml OK
publish.yml OK
```

Closes #70
Part of #68
