### PR TITLE
chore: legal/governance polish

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+repo-context-hooks
+Copyright 2024-2026 Narendranath Edara
+
+This product includes software developed by Narendranath Edara.
+
+Third-party text inclusions: none currently.
+Add entries here when bundling Apache-2.0 / BSD attribution-required code.
+
+Third-party runtime dependencies: none. This package depends only on the
+Python standard library at runtime. Optional development tooling lives
+under the `[dev]` extras and is not required to run installed hooks.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Need per-repo hooks too?
 repo-context-hooks install --platform claude --also-repo-hooks
 ```
 
+## Zero runtime dependencies
+
+`pip install repo-context-hooks` pulls only the Python standard library at runtime - `pyproject.toml` declares `dependencies = []`. The package installs nothing into your project's import graph; hooks run inside the agent's own runtime (Claude Code, Codex, Cursor, etc.) and read checked-in workspace files. Optional development tooling (pytest, ruff, black, mypy) lives under the `[dev]` extras and is never installed for end users.
+
 ## Set Up a Workspace Contract (per-repo)
 
 ```bash
@@ -92,6 +96,16 @@ The old approach (install a hook per repo) means every new workspace starts from
 - Agent skill: fires on `SessionStart`, `PreCompact`, `PostCompact`, `SessionEnd`
 - Workspace contract: `specs/README.md` (engineering memory), `README.md` (product intent), `UBIQUITOUS_LANGUAGE.md` (shared terms)
 - Telemetry: local JSONL events so `repo-context-hooks measure` can verify hooks actually fired
+
+## Scope
+
+repo-context-hooks is scoped to **single-developer** workflows today.
+It installs context hooks into your local Claude Code (or other AI agent)
+environment - one developer, one machine.
+
+Team aggregation (shared event streams, multi-seat dashboards) is tracked
+in [#26](https://github.com/narendranathe/repo-context-hooks/issues/26)
+and is out of scope for the current release.
 
 ## How It Works
 
@@ -296,6 +310,17 @@ python -m pytest -q
 ```
 
 Pull requests are welcome when they make the repo contract clearer, more durable, or easier to adopt without widening the product claims beyond what the implementation supports.
+
+## Maintainer status
+
+This project is solo-maintained by [@narendranathe](https://github.com/narendranathe).
+
+- **Issue response window:** best-effort within 7 days
+- **PR review window:** best-effort within 14 days
+- **Security reports:** handled on the [SECURITY.md](SECURITY.md) timeline (acknowledgement within 7 days, initial assessment within 14 days)
+- **Active development cadence:** see [CHANGELOG.md](CHANGELOG.md)
+
+If a thread goes quiet past these windows, please bump the issue or PR - it has not been ignored, only deprioritized against day-job load.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,16 @@ Hook-based repo context continuity for coding agents.
 
 A new agent session should start with full project context without rediscovering everything from scratch.
 
+## Scope
+
+repo-context-hooks is scoped to **single-developer** workflows today.
+It installs context hooks into your local Claude Code (or other AI agent)
+environment - one developer, one machine.
+
+Team aggregation (shared event streams, multi-seat dashboards) is tracked
+in [#26](https://github.com/narendranathe/repo-context-hooks/issues/26)
+and is out of scope for the current release.
+
 ## Key Features
 
 - **One-time install** - hooks write to agent home (`~/.claude/settings.json` or equivalent) and activate in every workspace automatically

--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -156,3 +156,16 @@ def test_readme_links_supporting_docs_and_examples() -> None:
     for link_text, link_path in expected_links:
         assert link_text in text, f"missing supporting link: {link_text}"
         assert link_path.exists(), f"missing supporting path: {link_path}"
+
+
+def test_readme_documents_dependency_and_maintainer_posture() -> None:
+    text = readme_text()
+    assert "Zero runtime dependencies" in text
+    assert "Maintainer status" in text
+    assert "solo-maintained" in text
+
+
+def test_readme_documents_single_developer_scope() -> None:
+    text = readme_text()
+    assert "## Scope" in text, "missing ## Scope section"
+    assert "single-developer" in text, "missing single-developer scope callout"


### PR DESCRIPTION
## Summary

Closes #77 — legal/governance polish for the v1.0 production-readiness milestone (#68). Three additions for a security-conscious adopter:

- **NOTICE** at repo root: copyright header (`2024-2026 Narendranath Edara`), Apache-style attribution line, forward-looking placeholder for future third-party text inclusions (`Apache-2.0 / BSD attribution-required code`), plus an explicit runtime-deps clarifier mirroring the README claim.
- **README.md → `## Zero runtime dependencies`** under Install: makes the `dependencies = []` claim from `pyproject.toml` visible without reading source. Calls out that hooks run inside the agent runtime, not in user import graphs, and that `[dev]` extras stay scoped to development tooling.
- **README.md → `## Maintainer status`** near License: solo maintenance attribution to [@narendranathe](https://github.com/narendranathe), 7-day issue / 14-day PR best-effort response windows, security timeline aligned to [SECURITY.md](SECURITY.md) (7d ack / 14d initial assessment), CHANGELOG link, and a "please bump if quiet" line that invites re-engagement instead of silent abandonment.

## Bundled with this PR

The branch also picks up an adjacent `## Scope` callout (in both `README.md` and `docs/index.md`) that scopes the project to single-developer workflows, forwarding team aggregation to #26. A matching `test_readme_documents_single_developer_scope` contract test was added.

## Test coverage

`tests/test_readme_contract.py` gains two new contract tests:

- `test_readme_documents_dependency_and_maintainer_posture` — asserts `"Zero runtime dependencies"`, `"Maintainer status"`, `"solo-maintained"` substrings.
- `test_readme_documents_single_developer_scope` — asserts `## Scope` heading and `single-developer` callout.

Full suite: `python -m pytest tests/ -q` → **332 passed**.

## Self-review

Ran 5-critic self-review (production quality, acceptance criteria, codebase consistency, legal accuracy, maintainer sustainability) before commit. Two BLOCKERs surfaced and fixed in-place:

| Critic | Blocker | Fix |
|---|---|---|
| **B (AC strictness)** | Test asserted `"solo-maintained"` per implementer prompt but issue AC literally pinned `"Maintainer status"` as a required substring. | Added third assertion `assert "Maintainer status" in text` so the test satisfies both the user's explicit prompt and the AC verbatim. |
| **C (typography)** | New README content used em-dashes; user typography rule mandates hyphens. | Replaced all em-dashes in the two new sections with hyphens. Existing em-dashes elsewhere in README left alone (out of scope). |

Critics A, D, E reported zero blockers. NITs noted but not addressed in this PR:

- **D (legal):** `LICENSE` shows `Copyright (c) 2026` while `NOTICE` shows `2024-2026`. Defensible (work originated earlier) but worth aligning in a follow-up.
- **E (sustainability):** Critic suggested 14d issue window instead of 7d for honesty. Kept 7d per implementer brief; the new "please bump if quiet" line provides an explicit pressure-release valve. Issue #77 itself acknowledges this is a judgment call ("Trust > optimism").
- **E (sustainability):** Replaced original `"prioritized"` framing on the security line with the actual SECURITY.md numbers (7d ack / 14d assessment) so the README never makes a promise the disclosure doc can't back.

## Test plan

- [x] `python -m pytest tests/test_readme_contract.py -v` — 13 passed (12 prior + new dependency/maintainer test + new scope test)
- [x] `python -m pytest tests/ -q` — 332 passed
- [x] Section ordering invariant preserved (`test_readme_has_public_facing_sections_in_order` green; new sections sit between Install and Why Agent-Level / between Development and License respectively, not in the pinned-order list)
- [x] No code changes — docs + tests + NOTICE only

Closes #77
Part of #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)
