### PR TITLE
chore: team-scope clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ The old approach (install a hook per repo) means every new workspace starts from
 - Workspace contract: `specs/README.md` (engineering memory), `README.md` (product intent), `UBIQUITOUS_LANGUAGE.md` (shared terms)
 - Telemetry: local JSONL events so `repo-context-hooks measure` can verify hooks actually fired
 
+## Scope
+
+**Today:** repo-context-hooks runs at **single-developer scope**. Each developer
+has their own local telemetry on their own machine; there is no shared team
+aggregation. The hooks work the same whether you are solo or one of fifty
+engineers each running them locally.
+
+**Roadmap:** team aggregation (shared event streams, multi-seat dashboards)
+is tracked in [#26](https://github.com/narendranathe/repo-context-hooks/issues/26).
+If your team needs this, leave a +1 on that issue.
+
 ## How It Works
 
 1. Agent skill loads at session start and reads workspace contract from repo

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,17 @@ Hook-based repo context continuity for coding agents.
 
 A new agent session should start with full project context without rediscovering everything from scratch.
 
+## Scope
+
+**Today:** repo-context-hooks runs at **single-developer scope**. Each developer
+has their own local telemetry on their own machine; there is no shared team
+aggregation. The hooks work the same whether you are solo or one of fifty
+engineers each running them locally.
+
+**Roadmap:** team aggregation (shared event streams, multi-seat dashboards)
+is tracked in [#26](https://github.com/narendranathe/repo-context-hooks/issues/26).
+If your team needs this, leave a +1 on that issue.
+
 ## Key Features
 
 - **One-time install** - hooks write to agent home (`~/.claude/settings.json` or equivalent) and activate in every workspace automatically

--- a/tests/test_readme_contract.py
+++ b/tests/test_readme_contract.py
@@ -156,3 +156,10 @@ def test_readme_links_supporting_docs_and_examples() -> None:
     for link_text, link_path in expected_links:
         assert link_text in text, f"missing supporting link: {link_text}"
         assert link_path.exists(), f"missing supporting path: {link_path}"
+
+
+def test_readme_documents_single_developer_scope() -> None:
+    text = readme_text()
+    assert "## Scope" in text, "missing ## Scope section"
+    assert "single-developer scope" in text, "missing single-developer scope callout"
+    assert "#26" in text, "missing roadmap link to issue #26"


### PR DESCRIPTION
## Summary

Adds a `## Scope` section to `README.md` and `docs/index.md` so a team lead can decide up front whether `repo-context-hooks` works for their team or just for them. Closes #78. Part of #68.

## What was added

**`README.md`** - new `## Scope` section inserted above `## How It Works`:

- `**Today:**` paragraph stating the tool runs at **single-developer scope** with no shared team aggregation, and noting the hooks work the same whether one developer or fifty are each running them locally.
- `**Roadmap:**` paragraph linking team aggregation (shared event streams, multi-seat dashboards) to [#26](https://github.com/narendranathe/repo-context-hooks/issues/26) with a "+1 on that issue" call-to-action.

**`docs/index.md`** - same `## Scope` section mirrored after the intro paragraph, before `## Key Features` so the docs site surfaces the limit at the same reading depth.

**`tests/test_readme_contract.py`** - new `test_readme_documents_single_developer_scope` asserting:
- `## Scope` heading is present
- `single-developer scope` phrase is present
- `#26` roadmap link is present

## Test coverage

```
tests/test_readme_contract.py::test_readme_documents_single_developer_scope PASSED
```

Full suite: 331 passed.

## Self-review

Ran 5 critic agents in parallel (production quality, acceptance criteria, codebase consistency, accuracy, product positioning) against the diff. Blockers fixed:

- **Critic B (acceptance criteria):** the issue's AC requires verbatim `Today:` / `Roadmap:` structure with the phrases "single-developer scope", "local telemetry", "shared team aggregation", and the "+1 on that issue" call-to-action. First draft used freer phrasing ("scoped to single-developer workflows today", "out of scope"); rewrote to match AC and updated the test to assert the literal phrase `single-developer scope` (the looser `single-developer` substring would have shipped if the README copy ever lost the word "scope").
- **Critic E (product positioning):** "out of scope for the current release" read as a backlog brush-off to a team lead. Replaced with the `Roadmap:` framing plus the line about hooks working the same whether you are solo or one of fifty engineers each running them locally — keeps the boundary honest without sounding dismissive.

NITs noted (deferred, not blockers):

- Test only validates `README.md` content; `docs/index.md` could drift independently. Left as a future tightening.
- Existing README has em-dashes elsewhere (e.g. line 13). New content uses hyphens per the global typography rule. A repo-wide normalization pass is a separate cleanup.
- Issue [#26](https://github.com/narendranathe/repo-context-hooks/issues/26) is framed as "consented remote telemetry" rather than literally "team aggregation / multi-seat dashboards". The issue's AC explicitly points to #26 for team aggregation, so the PR follows the AC; tightening #26's framing is upstream of this PR.

## Test plan

- [x] `python -m pytest tests/test_readme_contract.py -v` — new test passes
- [x] `python -m pytest tests/ -q` — 331 passed, no regressions
- [x] Read rendered `## Scope` section in README and confirmed Markdown layout, link, and bold spans render correctly
- [ ] On merge: confirm `docs/index.md` renders the same `## Scope` block on the GitHub Pages docs site

Closes #78
Part of #68
