### PR TITLE
feat(#71): enforce coverage gate and add property tests for telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,18 @@ jobs:
       - name: Install package and test deps
         run: pip install -e ".[dev]"
 
-      - name: Run tests
-        run: python -m pytest tests/ -q --tb=short
+      - name: Run tests with coverage
+        run: python -m pytest tests/ -q --tb=short --cov=repo_context_hooks --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to Codecov
+        # Only upload from the canonical repo + a single matrix cell to avoid 6x uploads
+        # and to keep fork CIs green (forks have no Codecov enrollment).
+        if: github.repository == 'narendranathe/repo-context-hooks' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          slug: narendranathe/repo-context-hooks
+          fail_ci_if_error: false
 
   install-smoke-test:
     name: Smoke test (${{ matrix.os }})

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ build/
 *.egg-info/
 .worktrees/
 .repo-context-hooks/
+.hypothesis/
+.coverage
+coverage.xml
+docs/internal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Coverage gate: `pyproject.toml` declares `[tool.coverage.run]` and `[tool.coverage.report] fail_under = 80`; CI enforces it on every push and PR (issue #71). Initial floor is 80%; current project coverage is ~83%, with `telemetry.py` at 86%. The 85% target is deferred to a follow-up that backfills `cli.py` tests (currently 67%, by far the largest gap).
+- Property-based tests via Hypothesis: `tests/test_property_telemetry.py` covers `is_sampled` boundary behaviour (rate ≥ 1.0 → True, rate ≤ 0.0 → False, mid-range cached decision is stable) and `repo_id` shape (16 lowercase hex chars, stable across calls); `tests/test_installer.py` adds an idempotency property test for `deduplicate_hooks` over realistic hook payloads
+- `tests/conftest.py`: autouse fixture clears `REPO_CONTEXT_HOOKS_*` env vars between tests so local dev environments do not leak telemetry decisions into the suite
+- `pytest-cov`, `hypothesis` added to `[project.optional-dependencies].dev`
+- README badge: Codecov status next to the existing context-score badge
+- CI uploads `coverage.xml` to Codecov via `codecov/codecov-action@v4` (gated on the canonical repo + one matrix cell so forks are not broken by missing enrollment)
+
 ## [0.6.0] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Agent-level continuity skill for coding agents.
 
 ![context score](docs/badge.svg)
+[![codecov](https://codecov.io/gh/narendranathe/repo-context-hooks/branch/main/graph/badge.svg)](https://codecov.io/gh/narendranathe/repo-context-hooks)
 
 <p align="center">
   <img src="assets/brand/repo-context-hooks-logo.png" alt="repo-context-hooks brand mark showing hook events flowing into an impact monitor" width="144">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7"]
+dev = ["pytest>=7", "pytest-cov>=4", "hypothesis>=6"]
 
 [project.urls]
 Homepage = "https://github.com/narendranathe/repo-context-hooks"
@@ -41,3 +41,31 @@ repo_context_hooks = ["bundle/**/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["repo_context_hooks"]
+branch = true
+relative_files = true
+omit = [
+    # CLI boilerplate that just delegates to repo_context_hooks.cli.main
+    "repo_context_hooks/__main__.py",
+    # Hook scripts shipped into agent_home and executed as subprocesses by Claude/Codex.
+    # Coverage of these is asserted by the install-smoke-test CI job, not by unit tests.
+    "repo_context_hooks/bundle/scripts/*",
+]
+
+[tool.coverage.report]
+# Initial floor is 80%, intentionally lower than the eventual 85% target.
+# The issue #71 risk note explicitly authorised "lower the gate to a true floor
+# (e.g., 80%) and ratchet up in a follow-up" — cli.py (372 stmts) is at 67% and
+# pulls the project total to ~83%. Driving cli.py up is its own scoped work,
+# tracked as a follow-up. The gate exists to PREVENT REGRESSION below the
+# current line; raising the number is mechanical once cli.py tests land.
+fail_under = 80
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Shared pytest fixtures for repo-context-hooks.
+
+Kept intentionally tiny so the existing 330-test suite is not perturbed.
+The autouse fixture below only clears `REPO_CONTEXT_HOOKS_*` env vars
+so a local dev environment cannot leak a sampling/consent decision into
+the test run.
+"""
+from __future__ import annotations
+
+import pytest
+
+_ENV_VARS_TO_CLEAR = (
+    "REPO_CONTEXT_HOOKS_TELEMETRY",
+    "REPO_CONTEXT_HOOKS_SAMPLE_RATE",
+    "REPO_CONTEXT_HOOKS_SESSION_ID",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_repo_context_hooks_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _ENV_VARS_TO_CLEAR:
+        monkeypatch.delenv(var, raising=False)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -714,3 +714,70 @@ def test_deduplicate_hooks_idempotent() -> None:
         f"Second dedup call must be a no-op; reported removed={second['removed']}"
     )
     _ = first  # first call result is not asserted — state may or may not have dupes
+
+
+# ---------------------------------------------------------------------------
+# Property-based idempotency over realistic hook payloads (issue #71)
+#
+# `deduplicate_hooks` is called from `install_global_hooks` on every agent
+# install. A regression that breaks idempotency would silently grow
+# settings.json on every run. The property: regardless of the input shape,
+# the on-disk JSON is byte-equal after a second call.
+# ---------------------------------------------------------------------------
+
+from hypothesis import given, settings as hyp_settings, strategies as st  # noqa: E402
+
+_HOOK_EVENT = st.sampled_from(
+    ["SessionStart", "PreCompact", "PostCompact", "SessionEnd", "PreToolUse", "PostToolUse"]
+)
+_HOOK_COMMAND = st.sampled_from(
+    [
+        'python "$CLAUDE_PROJECT_DIR"/.claude/scripts/repo_specs_memory.py session-start',
+        'python "$CLAUDE_PROJECT_DIR"/.claude/scripts/session_context.py session-start',
+        'python "$CLAUDE_PROJECT_DIR"/.claude/scripts/repo_specs_memory.py post-compact',
+        'python ./scripts/foo.py post-compact',
+        'echo "noop"',
+    ]
+)
+
+
+def _hook_entry(cmd: str) -> dict:
+    return {"type": "command", "command": cmd, "timeout": 10}
+
+
+def _matcher_group(cmds: list[str]) -> dict:
+    return {"matcher": "", "hooks": [_hook_entry(c) for c in cmds]}
+
+
+@st.composite
+def _settings_with_potential_dupes(draw) -> dict:
+    events = draw(st.lists(_HOOK_EVENT, min_size=1, max_size=4, unique=True))
+    hooks: dict = {}
+    for event in events:
+        cmds = draw(st.lists(_HOOK_COMMAND, min_size=1, max_size=4))
+        # Deliberately re-sample from the same list so duplicates are likely.
+        injected = draw(st.lists(st.sampled_from(cmds), min_size=0, max_size=2))
+        hooks[event] = [_matcher_group(cmds + injected)]
+    return {"hooks": hooks}
+
+
+@hyp_settings(derandomize=True, deadline=None, max_examples=40)
+@given(payload=_settings_with_potential_dupes())
+def test_deduplicate_hooks_idempotent_on_disk(payload: dict) -> None:
+    """Running `deduplicate_hooks` twice on the same input leaves settings.json byte-equal.
+
+    The function's RETURN value legitimately differs between calls (first
+    reports `{"removed": N>0}`, second reports `{"removed": 0}`). Idempotency
+    is a property of the on-disk state, not the return dict.
+    """
+    agent_home = _tmp_dir() / "home"
+    (agent_home / ".claude").mkdir(parents=True)
+    settings_path = agent_home / ".claude" / "settings.json"
+    settings_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    deduplicate_hooks(agent_home)
+    after_first = settings_path.read_text(encoding="utf-8")
+    deduplicate_hooks(agent_home)
+    after_second = settings_path.read_text(encoding="utf-8")
+
+    assert after_first == after_second

--- a/tests/test_property_telemetry.py
+++ b/tests/test_property_telemetry.py
@@ -1,0 +1,118 @@
+"""Property-based tests for telemetry hot paths.
+
+Issue #71 — the contract a downstream library author depends on:
+- `is_sampled(rate)` is True for every rate >= 1.0 and False for every rate <= 0.0
+- A mid-range rate produces a decision that is stable across consecutive calls
+  inside the same session (cache hit on the second call)
+- `repo_id(path)` returns 16 lowercase hex chars and is stable across calls in
+  the same process
+
+NaN and infinity rates are out-of-contract; strategies exclude them.
+Cross-process / cross-OS hash equality is NOT promised (Path.resolve normalises
+differently on Windows vs POSIX) — only the shape is.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+from repo_context_hooks.telemetry import is_sampled, repo_id
+
+# derandomize=True makes any failure deterministic so a CI flake is reproducible
+# locally instead of being a merge-blocking ghost. deadline=None protects the
+# Windows runners (which can be 5x slower than the Linux ones) from spurious
+# timeouts when the JSON-on-disk state writes happen. The function_scoped_fixture
+# suppression is intentional: every test below either nonces its own subdir under
+# tmp_path or uses the Hypothesis-generated `name` to disambiguate, so sharing the
+# parent tmp_path across examples is safe.
+_PROPERTY_SETTINGS = settings(
+    derandomize=True,
+    deadline=None,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+
+# Path components must be safe on every CI OS. Restrict to ASCII letters,
+# digits, hyphen, underscore, and dot — broad enough to exercise the codepath,
+# narrow enough to never hit a Windows path-syntax error mid-test.
+_PATH_NAME = st.text(
+    min_size=1,
+    max_size=40,
+    alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.",
+).filter(lambda s: s.strip(". ") != "")
+
+
+def _fresh_repo_root(tmp_path: Path) -> Path:
+    """Return a unique directory for each Hypothesis example.
+
+    Hypothesis calls the test function once and runs many examples inside it,
+    sharing the same `tmp_path`. Without this nonce, every example would write
+    to the same `_session_state_dir` and the cached sampling decision from one
+    example would poison the next.
+    """
+    p = tmp_path / uuid4().hex
+    p.mkdir()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# is_sampled
+# ---------------------------------------------------------------------------
+
+
+@_PROPERTY_SETTINGS
+@given(rate=st.floats(min_value=1.0, max_value=1e6, allow_nan=False, allow_infinity=False))
+def test_is_sampled_true_when_rate_ge_one(tmp_path: Path, rate: float) -> None:
+    repo_root = _fresh_repo_root(tmp_path)
+    assert is_sampled(repo_root, rate) is True
+
+
+@_PROPERTY_SETTINGS
+@given(rate=st.floats(min_value=-1e6, max_value=0.0, allow_nan=False, allow_infinity=False))
+def test_is_sampled_false_when_rate_le_zero(tmp_path: Path, rate: float) -> None:
+    repo_root = _fresh_repo_root(tmp_path)
+    assert is_sampled(repo_root, rate) is False
+
+
+@_PROPERTY_SETTINGS
+@given(rate=st.floats(min_value=0.001, max_value=0.999, allow_nan=False, allow_infinity=False))
+def test_is_sampled_cached_decision_is_stable(tmp_path: Path, rate: float) -> None:
+    """Two consecutive calls inside the same session return the same decision.
+
+    The first call may roll a random number; the second must read the persisted
+    decision file and return identically. This is the determinism the issue
+    asks for — `session_id` is not an argument of `is_sampled`, so determinism
+    actually flows from the cached `_SESSION_SAMPLED_FILE`.
+    """
+    repo_root = _fresh_repo_root(tmp_path)
+    first = is_sampled(repo_root, rate)
+    second = is_sampled(repo_root, rate)
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# repo_id
+# ---------------------------------------------------------------------------
+
+
+_HEX = frozenset("0123456789abcdef")
+
+
+@_PROPERTY_SETTINGS
+@given(name=_PATH_NAME)
+def test_repo_id_is_16_lowercase_hex_chars(tmp_path: Path, name: str) -> None:
+    repo_root = tmp_path / name
+    repo_root.mkdir(exist_ok=True)
+    rid = repo_id(repo_root)
+    assert len(rid) == 16
+    assert set(rid).issubset(_HEX)
+
+
+@_PROPERTY_SETTINGS
+@given(name=_PATH_NAME)
+def test_repo_id_stable_across_calls(tmp_path: Path, name: str) -> None:
+    repo_root = tmp_path / name
+    repo_root.mkdir(exist_ok=True)
+    assert repo_id(repo_root) == repo_id(repo_root)


### PR DESCRIPTION
Closes #71. Wave 2 / M3 from PRD #68.

## Summary

- **Gate** — `pytest-cov` + Hypothesis in dev deps; `[tool.coverage.run]` and `[tool.coverage.report]` declared in `pyproject.toml` (single source of truth); CI runs pytest with coverage on the full 6-cell matrix and uploads `coverage.xml` to Codecov from one canonical cell so forks stay green.
- **Property tests** — `tests/test_property_telemetry.py` exercises the boundary and stability contracts of `is_sampled` and `repo_id`; `tests/test_installer.py` gains an idempotency property test for `deduplicate_hooks` over realistic hook payloads.
- **Floor** — initial gate is 80% (project total today is 83%, `telemetry.py` 86%); raising to 85% is mechanical once `cli.py` (currently 67%) gets its own scoped backfill.

## Acceptance criteria

- [x] `pyproject.toml` `[project.optional-dependencies].dev` adds `pytest-cov`, `hypothesis`
- [x] `pyproject.toml` adds `[tool.coverage.run]` source=`repo_context_hooks` and `[tool.coverage.report]` `fail_under` *(set to 80; see Self-review)*
- [x] `.github/workflows/ci.yml` `pytest` step runs with `--cov=repo_context_hooks --cov-report=xml --cov-report=term` *(no `--cov-fail-under` on CLI — pyproject is canonical)*
- [x] CI uploads `coverage.xml` to Codecov via `codecov/codecov-action@v4`
- [x] `README.md` adds Codecov badge next to the existing context-score badge
- [x] `tests/test_property_telemetry.py` ships Hypothesis tests for `is_sampled` (rate ≥ 1.0 → True, rate ≤ 0.0 → False, mid-range cached decision is stable) and `repo_id` (16 lowercase hex chars, stable across calls)
- [x] `deduplicate_hooks` idempotency property test is added — placed in `tests/test_installer.py` next to the existing scalar idempotency test, since the function lives in `platforms/runtime.py`, not `telemetry.py`
- [x] All existing 330+ tests still pass — 338 pass locally with the gate enabled
- [x] `telemetry.py`-specific coverage documented — currently **86%**, above the project floor; the 90% stretch from PRD #68 stays a Wave 2/3 follow-up

## Self-review — non-negotiables (the three critic objections that survived consensus)

1. **Codecov must not break fork CIs (Critic A — global adoption).**
   Resolution: the upload step is gated on `if: github.repository == 'narendranathe/repo-context-hooks' && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'`. Forks run the coverage gate (portable) but skip the upload (which needs enrollment). The Codecov badge defaults to "unknown" on a fork — acceptable since the gate is what enforces quality, not the badge.

2. **Test files must mirror the modules they cover (Critic B — repo conventions).**
   Resolution: `is_sampled` and `repo_id` properties live in `tests/test_property_telemetry.py`; the `deduplicate_hooks` property test lives in `tests/test_installer.py` adjacent to the existing `test_deduplicate_hooks_idempotent` at line 703. The issue body wrongly placed `deduplicate_hooks` in `telemetry.py`; the function is actually in `repo_context_hooks/platforms/runtime.py:194`. Splitting the file keeps grep-discoverability honest.

3. **State and env must be isolated, and Hypothesis must be derandomised (Critic C — failure modes).**
   Resolution: new `tests/conftest.py` autouse fixture clears `REPO_CONTEXT_HOOKS_TELEMETRY`, `REPO_CONTEXT_HOOKS_SAMPLE_RATE`, and `REPO_CONTEXT_HOOKS_SESSION_ID` so a local dev opt-out cannot poison the suite. Every Hypothesis test uses `settings(derandomize=True, deadline=None, max_examples=50)` plus `suppress_health_check=[HealthCheck.function_scoped_fixture]`, since each property test either nonces its own subdir under `tmp_path` or uses the generated `name` to disambiguate. NaN/infinity rates are excluded from float strategies as out-of-contract — documented in the test module so a future contributor doesn't try to "fix" it.

### One additional decision worth flagging

The issue body specified `fail_under = 85`. The same issue's risk note explicitly authorised "lower the gate to a true floor (e.g., 80%) and ratchet up in a follow-up" if `cli.py` came in low. cli.py is at 67% (109 of 372 statements uncovered, mostly in `_checkpoint`, `_measure --clean-ghosts`, `_measure export`, `experiment` subcommands). I chose the documented fallback over driving the number with shallow tests. CHANGELOG records the floor and the ratchet plan.

## Test plan

```bash
# 1. Install dev deps
pip install -e ".[dev]"

# 2. Run the new property tests in isolation
python -m pytest tests/test_property_telemetry.py tests/test_installer.py::test_deduplicate_hooks_idempotent_on_disk -v

# 3. Run the full suite with the new gate enabled
python -m pytest tests/ -q --cov=repo_context_hooks --cov-report=term

# Expected:
#   338 passed
#   TOTAL ... 83%
#   Required test coverage of 80.0% reached. Total coverage: 83.31%
#   telemetry.py — 86%

# 4. Confirm CI yaml renders the upload gate the way you'd expect on a fork
git grep -n "github.repository == 'narendranathe" .github/workflows/ci.yml
```