### PR TITLE
feat(#72): define public API surface and deprecation policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,36 @@ jobs:
           }
           Write-Host "No backslash paths - OK"
 
+  public-surface-guard:
+    # Stability-contract enforcement (issue #72). Compares the introspected
+    # public surface of the package against the committed snapshot at
+    # `tests/contract/public_surface.json`, then -- in `--verify-removals`
+    # mode -- diffs against the snapshot at the previous release tag and
+    # requires every removal to be excused by a matching `### Deprecated`
+    # bullet (in some prior version) plus a `### Removed` bullet under
+    # `[Unreleased]` in CHANGELOG.md. See docs/stability.md.
+    name: Public surface guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Required so the gate can `git show <prior-tag>:tests/contract/public_surface.json`.
+          # `fetch-depth: 1` (the default) hides every prior tag and the gate would
+          # silently pass on a shallow clone -- exactly the failure mode this job
+          # exists to prevent.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PRIMARY_PYTHON }}
+
+      - name: Install package
+        run: pip install -e .
+
+      - name: Verify drift + verify removals against prior release tag
+        run: python scripts/check_public_surface.py --verify-removals
+
   platform-matrix:
     name: Platform matrix (${{ matrix.platform }})
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - `tests/test_bundle_scripts_compile.py`: `py_compile` smoke for every script shipped under `bundle/`.
 - `tests/test_telemetry_edge_cases.py`: NaN/+inf/-inf rate contracts.
 - README Codecov badge inside `<!-- BADGES:START/END -->` anchor block.
+- Public-API stability contract (issue #72): explicit `__all__ = ["__version__"]` in `repo_context_hooks/__init__.py`, machine-readable snapshot at `tests/contract/public_surface.json`, CI gate `scripts/check_public_surface.py` (drift check + `--verify-removals` mode against prior release tag), and contract tests under `tests/contract/`. `docs/stability.md` and `docs/deprecation-policy.md` document stable vs internal surfaces and the one-MINOR-cycle deprecation rule. README adds `## Stability` section. (#72)
 
 ### Changed
 - `is_sampled`: NaN sample-rate now coerces to 0.0 (safe-default opt-out) instead of silently falling through to `random.random() < NaN` and returning False with no diagnostic. (issue #71 audit follow-up)

--- a/README.md
+++ b/README.md
@@ -352,6 +352,15 @@ This project is solo-maintained by [@narendranathe](https://github.com/narendran
 
 If a thread goes quiet past these windows, please bump the issue or PR - it has not been ignored, only deprioritized against day-job load.
 
+## Stability
+
+`repo-context-hooks` follows [SemVer 2.0.0](https://semver.org/) starting at the `1.0.0` release. The public surface — console scripts, CLI subcommands, documented flags, `REPO_CONTEXT_HOOKS_*` env vars, and the file locations of `events.jsonl` and `settings.json` writes — will not break across a `1.x → 1.y` bump without first being deprecated for at least one full MINOR cycle.
+
+- [Stability contract](docs/stability.md) — full list of stable vs internal surfaces
+- [Deprecation policy](docs/deprecation-policy.md) — how we remove things from the surface above
+
+The contract is enforced in CI by `scripts/check_public_surface.py`, which compares the running package against the snapshot in `tests/contract/public_surface.json`. A removal that does not follow the deprecation policy fails the build.
+
 ## License
 
 MIT

--- a/docs/deprecation-policy.md
+++ b/docs/deprecation-policy.md
@@ -1,0 +1,116 @@
+# Deprecation Policy
+
+This document explains how we remove things from the [stability contract](stability.md) without breaking downstream users.
+
+## The rule
+
+**A public surface symbol must be marked deprecated for at least one full MINOR release before it is removed.**
+
+Concretely, to remove a public symbol in version `1.N`:
+
+1. In version `1.N-1` (or earlier), land a `### Deprecated` entry in [`CHANGELOG.md`](https://github.com/narendranathe/repo-context-hooks/blob/main/CHANGELOG.md) and emit a `DeprecationWarning` from the runtime when the symbol is touched.
+2. In version `1.N`, land a `### Removed` entry referencing the prior `### Deprecated` entry, drop the symbol from `repo_context_hooks/__init__.py`, the CLI parser, or the env-var reader, and update `tests/contract/public_surface.json` in the same PR.
+
+A removal in `1.N` that was not deprecated in some earlier `1.x` is **not allowed**. The CI gate (`scripts/check_public_surface.py --verify-removals`) blocks the PR.
+
+A MAJOR bump (`1.x → 2.0`) may remove deprecated symbols in bulk, but may not introduce *new* removals — every removal in `2.0` must trace back to a `### Deprecated` entry in some `1.x`.
+
+## CHANGELOG flow
+
+Every deprecation lives in `CHANGELOG.md` under the [Unreleased] / target-version block, in this shape:
+
+```markdown
+### Deprecated
+
+- `<symbol>`: deprecated in <version>, scheduled for removal in <version>.
+  Migration: <one-line action the user should take>.
+  See <link to issue or doc>.
+```
+
+And later, when removed:
+
+```markdown
+### Removed
+
+- `<symbol>`: removed in <version>; was deprecated in <version> (see CHANGELOG entry above).
+```
+
+The CI gate parses these lines, so the bullet text must contain the symbol name in backticks. Anything else is freeform.
+
+## Per-context guidance
+
+The mechanism for emitting a `DeprecationWarning` differs depending on what is being deprecated.
+
+### Python imports (`__all__` removal)
+
+Use `warnings.warn(...)` at module import time:
+
+```python
+import warnings
+warnings.warn(
+    "`repo_context_hooks.foo` is deprecated and will be removed in 1.4. "
+    "Use `repo_context_hooks.bar` instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+```
+
+`stacklevel=2` attributes the warning to the caller's frame, not the warning site.
+
+### CLI flag removal
+
+The deprecated flag stays accepted by the parser. On invocation it emits a warning to stderr (not via Python `warnings`, because most CLI users don't enable `-W default`):
+
+```python
+parser.add_argument(
+    "--old-flag",
+    action="store_true",
+    help="(deprecated, use --new-flag — will be removed in 1.4)",
+)
+# in the dispatch:
+if args.old_flag:
+    print(
+        "warning: --old-flag is deprecated and will be removed in 1.4; use --new-flag",
+        file=sys.stderr,
+    )
+```
+
+The help text also marks the flag deprecated, which keeps `--help` users informed.
+
+### CLI subcommand removal
+
+Same shape as a flag: the subcommand stays registered, runs its old behaviour, and prints a deprecation line to stderr before doing the work. The CHANGELOG `### Deprecated` bullet names the subcommand.
+
+### Environment variable removal
+
+The reader continues to honour the old name for one full MINOR. If both old and new are set, prefer the new one and warn that the old one was ignored. If only the old one is set, honour it and warn that it is deprecated.
+
+### `--platform` choice removal
+
+`argparse`'s default `choices=` validation will hard-reject a removed value with `SystemExit(2)`, which gives the user no migration path. The deprecation must use a custom `argparse.Action` that:
+
+1. Accepts the deprecated value.
+2. Emits a `DeprecationWarning` with the replacement (or `none`).
+3. Maps it to the replacement value internally so the rest of the code path is unchanged.
+
+Once the cycle expires, the value is removed from both the custom action and `tests/contract/public_surface.json::platform_choices`.
+
+## Migration paths are mandatory
+
+Every `### Deprecated` bullet **must** include a one-line migration path. "Use `X` instead", or "remove the call site", or "set `Y=z` in your config". A deprecation without a migration path is a slow-rolling break and gets rejected in review.
+
+## What is *not* covered
+
+This policy applies only to surfaces listed under [Stability — Stable surfaces](stability.md#stable-surfaces). Internal surfaces (everything else) may change in any release, including patch. There is no obligation to deprecate an internal symbol — the warning we owe users is the [stability doc](stability.md) itself, which says these surfaces are not promised.
+
+If you discover that you are relying on an internal surface, the right step is to open an issue requesting promotion. We will weigh the use case and either promote it (which lands as a new `### Added` entry on the public surface) or document a workaround.
+
+## SemVer alignment
+
+We follow [SemVer 2.0.0](https://semver.org/) starting at `1.0.0`. In short:
+
+- **PATCH** (`1.0.x`) — backwards-compatible bug fixes only. No surface change.
+- **MINOR** (`1.x.0`) — backwards-compatible additions and `### Deprecated` markers. No removals from the public surface.
+- **MAJOR** (`x.0.0`) — may remove anything that was deprecated in a prior MINOR. May not introduce new, non-deprecated removals.
+
+This is the deal. The CI gate is the enforcement. If the gate fails, the contract caught a bug — fix the contract path, don't bypass the gate.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,111 @@
+# Stability Contract
+
+`repo-context-hooks` follows [Semantic Versioning 2.0.0](https://semver.org/) starting at the `1.0.0` release. This page is the canonical answer to **"what can I rely on across a 1.x → 1.y bump?"**.
+
+If a behaviour is listed under [Stable surfaces](#stable-surfaces), we will not break it without first going through the [deprecation policy](deprecation-policy.md). If a behaviour is listed under [Internal surfaces](#internal-surfaces), we may change it at any time, including in a patch release.
+
+The contract is enforced in CI by `scripts/check_public_surface.py`, which compares the running package against the snapshot in `tests/contract/public_surface.json`. A removal that does not follow the deprecation policy fails the build.
+
+---
+
+## Stable surfaces
+
+These will not break before the next MAJOR release without first being deprecated for at least one full MINOR cycle.
+
+### Console scripts
+
+The package installs three console scripts. All three resolve to the same CLI; the additional names exist for muscle-memory compatibility:
+
+- `repo-context-hooks`
+- `repohandoff`
+- `graphify`
+
+Removing any of these names is a breaking change.
+
+### CLI subcommands
+
+Every documented subcommand of the CLI:
+
+- `install`
+- `init`
+- `doctor`
+- `recommend`
+- `measure` (including `measure export`, `measure experiment {start,finish,status}`)
+- `platforms`
+- `uninstall`
+- `checkpoint`
+- `telemetry` (including `telemetry status`, `telemetry preview`, `telemetry enable`, `telemetry disable`)
+
+The full list of subcommand names and their flags is enumerated in `tests/contract/public_surface.json::cli_commands`.
+
+### CLI flags
+
+Every documented flag on the subcommands above is part of the contract. Renaming, removing, or changing the type of a flag requires a deprecation cycle.
+
+Adding a new flag is non-breaking. Adding a new subcommand is non-breaking.
+
+### `--platform` choices
+
+The accepted values for `--platform` (`claude`, `cursor`, `codex`, `replit`, `windsurf`, `lovable`, `openclaw`, `ollama`, `kimi`) are part of the contract. Removing a platform from this list is a breaking change and follows the deprecation policy: the value continues to be accepted for one MINOR cycle, emits a `DeprecationWarning`, and points the user to the replacement (or `none`).
+
+Adding a new platform is non-breaking.
+
+### Environment variables
+
+The `REPO_CONTEXT_HOOKS_*` namespace, as documented in [TELEMETRY.md](https://github.com/narendranathe/repo-context-hooks/blob/main/TELEMETRY.md). Today this includes:
+
+- `REPO_CONTEXT_HOOKS_TELEMETRY` — `0`/`1` toggle, hard opt-out
+- `REPO_CONTEXT_HOOKS_TELEMETRY_DIR` — directory override for the telemetry log
+- `REPO_CONTEXT_HOOKS_SAMPLE_RATE` — float in `[0.0, 1.0]`, defaults to `1.0`
+- `REPO_CONTEXT_HOOKS_SESSION_ID` — UUID override for deterministic test runs
+
+The full list lives in `tests/contract/public_surface.json::env_vars`. Removing or renaming any of these requires a deprecation cycle. Both names continue to be read for one full MINOR.
+
+### File locations
+
+- `~/.cache/repo-context-hooks/events.jsonl` (Linux, macOS) — telemetry evidence log
+- `%LOCALAPPDATA%\repo-context-hooks\events.jsonl` (Windows) — telemetry evidence log
+- `~/.claude/settings.json` — agent-level hook installation target (we own only the hook entries we wrote; the rest is the user's)
+- `<repo>/.claude/settings.json` — workspace-level hook installation target (same ownership rule)
+- `<repo>/specs/README.md` `## Session Log` heading — checkpoint append target
+
+These locations and the partial-ownership rule will not change before MAJOR.
+
+### Python API
+
+```python
+from repo_context_hooks import __version__
+```
+
+That is the entire stable Python surface. `__all__` in `repo_context_hooks/__init__.py` is the source of truth.
+
+If you are importing anything else, you are using an internal surface and you should expect it to change.
+
+---
+
+## Internal surfaces
+
+These may change in any release, including patch.
+
+- Every submodule of `repo_context_hooks` not re-exported via `__all__`: `cli`, `installer`, `doctor`, `recommend`, `repo_contract`, `consent`, `telemetry`, `badge`, every module under `platforms/`.
+- Internal helpers and private functions (anything prefixed with `_`).
+- The shape of records written to `events.jsonl` beyond the documented core schema (see [TELEMETRY.md](https://github.com/narendranathe/repo-context-hooks/blob/main/TELEMETRY.md) for the documented core).
+- Exit-code values beyond the binary "zero on success, non-zero on failure" guarantee. Specific non-zero exit codes are not stable and should not be branched on by scripts.
+- The exact text of log lines, error messages, and console output. Tests should not regex against these.
+- Bundle scripts under `repo_context_hooks/bundle/scripts/` — these are subprocess-invoked by hooks and their internal layout is an implementation detail.
+- The HTML and SVG output of `measure --badge`, `measure export --format markdown`, and the dashboard at `docs/monitoring/`.
+
+---
+
+## Why a public surface this small
+
+`repo-context-hooks` is a tool you install, not a library you import. The CLI is the primary product. Keeping the Python `__all__` minimal lets us refactor the internals freely without breaking anyone in the wild.
+
+If you need a function from an internal submodule for a real use case, open an issue describing the use case and we will consider promoting it. Promotion is its own change and lands in the `### Added` section of the next release.
+
+---
+
+## Related
+
+- [Deprecation policy](deprecation-policy.md) — how we remove things from the surface above
+- [Telemetry policy](telemetry-policy.md) — what we collect and where it goes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,9 @@ nav:
   - Platforms: platforms.md
   - Platform Playbooks: platform-playbooks.md
   - Telemetry Policy: telemetry-policy.md
+  - Stability:
+      - Overview: stability.md
+      - Deprecation Policy: deprecation-policy.md
   - Monitoring: monitoring.md
   - Competitive Analysis: competitive-analysis.md
 

--- a/scripts/check_public_surface.py
+++ b/scripts/check_public_surface.py
@@ -1,0 +1,464 @@
+"""Public-API stability gate for `repo-context-hooks`.
+
+Two modes:
+
+1. **Drift check** (default): assert the introspected public surface of the
+   currently-installed `repo_context_hooks` matches the committed snapshot at
+   `tests/contract/public_surface.json`. Catches unannounced surface changes
+   inside a single PR and runs as a `pytest` test so it travels with the
+   package -- forks, monorepo vendors, and contributors without GitHub Actions
+   are still protected.
+
+2. **Removal check** (`--verify-removals`): in addition to drift, compare the
+   current snapshot against the snapshot at the previous release tag. Any
+   removal must be excused by a matching `### Deprecated` bullet in the prior
+   `CHANGELOG.md` *and* a `### Removed` bullet in the current `[Unreleased]`
+   block. This mode runs in CI with `fetch-depth: 0` + `fetch-tags: true` and
+   self-verifies it can resolve the prior tag -- a shallow clone hard-fails
+   rather than passing silently.
+
+The script is pure stdlib (zero new runtime deps).
+
+See `docs/stability.md` and `docs/deprecation-policy.md` for the contract this
+gate enforces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "contract" / "public_surface.json"
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+
+ENV_VAR_PATTERN = re.compile(
+    r'os\.(?:environ\.get|getenv)\(\s*["\'](REPO_CONTEXT_HOOKS_[A-Z0-9_]+)["\']'
+)
+
+
+# ---------------------------------------------------------------------------
+# Introspection
+# ---------------------------------------------------------------------------
+
+
+def introspect_surface() -> dict[str, Any]:
+    """Compute the package's current public surface."""
+    import repo_context_hooks  # noqa: WPS433
+    from repo_context_hooks import cli  # noqa: WPS433
+
+    parser = cli.build_parser()
+    sub_action = _find_subparsers_action(parser)
+    cli_commands = []
+    platform_choices: list[str] = []
+    for name in sorted(sub_action.choices):
+        sp = sub_action.choices[name]
+        flags = _extract_flags(sp)
+        sub_subparsers = _extract_subcommands(sp)
+        cmd: dict[str, Any] = {"name": name, "flags": flags}
+        if sub_subparsers:
+            cmd["subcommands"] = sub_subparsers
+        cli_commands.append(cmd)
+        if name == "install":
+            platform_choices = _extract_platform_choices(sp)
+
+    env_vars = sorted(_grep_env_vars(REPO_ROOT / "repo_context_hooks"))
+
+    return {
+        "all": sorted(repo_context_hooks.__all__),
+        "console_scripts": _read_console_scripts(),
+        "cli_commands": cli_commands,
+        "platform_choices": platform_choices,
+        "env_vars": env_vars,
+    }
+
+
+def _find_subparsers_action(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    raise RuntimeError("CLI parser exposes no subparsers; cannot introspect public surface.")
+
+
+def _extract_flags(parser: argparse.ArgumentParser) -> list[str]:
+    flags: set[str] = set()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            continue
+        if action.option_strings:
+            for opt in action.option_strings:
+                if opt in ("-h", "--help"):
+                    continue
+                flags.add(opt)
+    return sorted(flags)
+
+
+def _extract_subcommands(parser: argparse.ArgumentParser) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            for sub_name in sorted(action.choices):
+                sub_parser = action.choices[sub_name]
+                out.append({"name": sub_name, "flags": _extract_flags(sub_parser)})
+    return out
+
+
+def _extract_platform_choices(install_parser: argparse.ArgumentParser) -> list[str]:
+    for action in install_parser._actions:
+        if "--platform" in action.option_strings and action.choices:
+            return sorted(action.choices)
+    return []
+
+
+def _read_console_scripts() -> list[str]:
+    pyproject = REPO_ROOT / "pyproject.toml"
+    text = pyproject.read_text(encoding="utf-8-sig")
+    in_scripts = False
+    scripts: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "[project.scripts]":
+            in_scripts = True
+            continue
+        if in_scripts:
+            if stripped.startswith("[") and stripped.endswith("]"):
+                break
+            if "=" in stripped and not stripped.startswith("#"):
+                name = stripped.split("=", 1)[0].strip()
+                if name:
+                    scripts.append(name)
+    return sorted(scripts)
+
+
+def _grep_env_vars(root: Path) -> set[str]:
+    """Walk python sources under `root` and collect every `REPO_CONTEXT_HOOKS_*`
+    name read via `os.environ.get(...)` or `os.getenv(...)`.
+    """
+    found: set[str] = set()
+    for path in root.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8-sig")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for match in ENV_VAR_PATTERN.finditer(text):
+            found.add(match.group(1))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Snapshot I/O
+# ---------------------------------------------------------------------------
+
+
+def load_snapshot(path: Path = SNAPSHOT_PATH) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8-sig")
+    snap = json.loads(text)
+    return _normalize(snap)
+
+
+def _normalize(snap: dict[str, Any]) -> dict[str, Any]:
+    """Drop schema-only metadata so the comparison is over surface keys only."""
+    return {k: v for k, v in snap.items() if not k.startswith("_") and k != "schema_version"}
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+
+def diff_surface(snapshot: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    """Return a list of human-readable drift messages. Empty list = no drift."""
+    msgs: list[str] = []
+    snap_norm = _normalize(snapshot)
+    for pillar in ("all", "console_scripts", "platform_choices", "env_vars"):
+        s = set(snap_norm.get(pillar) or [])
+        c = set(current.get(pillar) or [])
+        for added in sorted(c - s):
+            msgs.append(f"[{pillar}] added '{added}' to source but missing from snapshot.")
+        for removed in sorted(s - c):
+            msgs.append(f"[{pillar}] removed '{removed}' from source but still in snapshot.")
+
+    msgs.extend(
+        _diff_cli_commands(
+            snap_norm.get("cli_commands") or [],
+            current.get("cli_commands") or [],
+        )
+    )
+    return msgs
+
+
+def _diff_cli_commands(snap_cmds: list[dict[str, Any]], cur_cmds: list[dict[str, Any]]) -> list[str]:
+    out: list[str] = []
+    snap_by_name = {c["name"]: c for c in snap_cmds}
+    cur_by_name = {c["name"]: c for c in cur_cmds}
+    for added in sorted(set(cur_by_name) - set(snap_by_name)):
+        out.append(f"[cli_commands] added subcommand '{added}' not in snapshot.")
+    for removed in sorted(set(snap_by_name) - set(cur_by_name)):
+        out.append(f"[cli_commands] removed subcommand '{removed}' still in snapshot.")
+    for name in sorted(set(snap_by_name) & set(cur_by_name)):
+        s_flags = set(snap_by_name[name].get("flags") or [])
+        c_flags = set(cur_by_name[name].get("flags") or [])
+        for added in sorted(c_flags - s_flags):
+            out.append(f"[cli_commands] '{name}': added flag '{added}' not in snapshot.")
+        for removed in sorted(s_flags - c_flags):
+            out.append(f"[cli_commands] '{name}': removed flag '{removed}' still in snapshot.")
+        s_subs = {x["name"]: x for x in snap_by_name[name].get("subcommands") or []}
+        c_subs = {x["name"]: x for x in cur_by_name[name].get("subcommands") or []}
+        for added in sorted(set(c_subs) - set(s_subs)):
+            out.append(f"[cli_commands] '{name} {added}': added subcommand not in snapshot.")
+        for removed in sorted(set(s_subs) - set(c_subs)):
+            out.append(f"[cli_commands] '{name} {removed}': removed subcommand still in snapshot.")
+        for sub_name in sorted(set(s_subs) & set(c_subs)):
+            s_sub_flags = set(s_subs[sub_name].get("flags") or [])
+            c_sub_flags = set(c_subs[sub_name].get("flags") or [])
+            for added in sorted(c_sub_flags - s_sub_flags):
+                out.append(f"[cli_commands] '{name} {sub_name}': added flag '{added}' not in snapshot.")
+            for removed in sorted(s_sub_flags - c_sub_flags):
+                out.append(f"[cli_commands] '{name} {sub_name}': removed flag '{removed}' still in snapshot.")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Removal-vs-prior-tag mode
+# ---------------------------------------------------------------------------
+
+
+def removed_symbols_vs_baseline(baseline_snap: dict[str, Any], current_snap: dict[str, Any]) -> list[str]:
+    """Symbols present in baseline_snap but absent from current_snap."""
+    removed: list[str] = []
+    snap_a = _normalize(baseline_snap)
+    snap_b = _normalize(current_snap)
+    for pillar in ("all", "console_scripts", "platform_choices", "env_vars"):
+        a = set(snap_a.get(pillar) or [])
+        b = set(snap_b.get(pillar) or [])
+        for sym in sorted(a - b):
+            removed.append(f"{pillar}:{sym}")
+    a_cmds = {c["name"]: c for c in snap_a.get("cli_commands") or []}
+    b_cmds = {c["name"]: c for c in snap_b.get("cli_commands") or []}
+    for name in sorted(set(a_cmds) - set(b_cmds)):
+        removed.append(f"cli_commands:{name}")
+    for name in sorted(set(a_cmds) & set(b_cmds)):
+        a_flags = set(a_cmds[name].get("flags") or [])
+        b_flags = set(b_cmds[name].get("flags") or [])
+        for f in sorted(a_flags - b_flags):
+            removed.append(f"cli_commands:{name}:{f}")
+    return removed
+
+
+def parse_changelog_deprecations(changelog_text: str) -> dict[str, list[str]]:
+    """Return `{version_header: [bullet_text, ...]}` for every `### Deprecated`
+    block. Tolerant of utf-8-sig BOM, CRLF endings, and mixed-case headings.
+    """
+    text = changelog_text.replace("\r\n", "\n").replace("\r", "\n")
+    if text.startswith("﻿"):
+        text = text[1:]
+    out: dict[str, list[str]] = {}
+    current_version: str | None = None
+    in_deprecated = False
+    bullets: list[str] = []
+    for line in text.split("\n"):
+        m = re.match(r"^##\s+\[([^\]]+)\]", line.strip())
+        if m:
+            if current_version is not None and bullets:
+                out.setdefault(current_version, []).extend(bullets)
+            current_version = m.group(1)
+            in_deprecated = False
+            bullets = []
+            continue
+        h3 = re.match(r"^###\s+(\w+)", line.strip())
+        if h3:
+            if in_deprecated and bullets and current_version is not None:
+                out.setdefault(current_version, []).extend(bullets)
+                bullets = []
+            in_deprecated = h3.group(1).lower() == "deprecated"
+            continue
+        if in_deprecated and line.strip().startswith("-"):
+            bullets.append(line.strip())
+    if in_deprecated and bullets and current_version is not None:
+        out.setdefault(current_version, []).extend(bullets)
+    return out
+
+
+def parse_changelog_removed_unreleased(changelog_text: str) -> list[str]:
+    """Bullets under `[Unreleased] ### Removed`. Same tolerance as above."""
+    text = changelog_text.replace("\r\n", "\n").replace("\r", "\n")
+    if text.startswith("﻿"):
+        text = text[1:]
+    in_unreleased = False
+    in_removed = False
+    bullets: list[str] = []
+    for line in text.split("\n"):
+        m = re.match(r"^##\s+\[([^\]]+)\]", line.strip())
+        if m:
+            in_unreleased = m.group(1).lower() == "unreleased"
+            in_removed = False
+            continue
+        h3 = re.match(r"^###\s+(\w+)", line.strip())
+        if h3 and in_unreleased:
+            in_removed = h3.group(1).lower() == "removed"
+            continue
+        if in_unreleased and in_removed and line.strip().startswith("-"):
+            bullets.append(line.strip())
+    return bullets
+
+
+def _bullet_mentions(bullets: Iterable[str], symbol: str) -> bool:
+    return any(symbol in b for b in bullets)
+
+
+def explain_removal_violation(
+    removed_key: str,
+    deprecations: dict[str, list[str]],
+    removed_bullets: list[str],
+) -> str | None:
+    """Return None if the removal is excused, else a human-readable error."""
+    pillar, _, rest = removed_key.partition(":")
+    symbol = rest.split(":")[-1] if ":" in rest else rest
+    deprecated_anywhere = any(_bullet_mentions(bs, symbol) for bs in deprecations.values())
+    removed_now = _bullet_mentions(removed_bullets, symbol)
+    if deprecated_anywhere and removed_now:
+        return None
+    parts = [f"public-surface removal '{removed_key}' is not excused."]
+    if not deprecated_anywhere:
+        parts.append(
+            f"  No prior `### Deprecated` CHANGELOG entry mentions `{symbol}`. "
+            "See docs/deprecation-policy.md -- a removal must be deprecated for one full MINOR cycle first."
+        )
+    if not removed_now:
+        parts.append(
+            f"  No `### Removed` entry under `[Unreleased]` mentions `{symbol}`. "
+            "Add one citing the prior `### Deprecated` entry."
+        )
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Git baseline access
+# ---------------------------------------------------------------------------
+
+
+def can_resolve_prior_tag(repo: Path = REPO_ROOT) -> tuple[bool, str | None, str]:
+    """Return (ok, tag_name, diagnostic). When ok is False, the diagnostic is an
+    actionable message for the operator.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "tag", "--sort=-v:refname"],
+            cwd=str(repo),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False, None, "git is not on PATH; cannot resolve prior tag for removal check."
+    if result.returncode != 0:
+        return False, None, f"git tag failed: {result.stderr.strip()}"
+    tags = [t for t in result.stdout.splitlines() if t.strip()]
+    if not tags:
+        return False, None, (
+            "No tags reachable. If running in CI, set `fetch-depth: 0` and `fetch-tags: true` on actions/checkout. "
+            "If this is the first release before any tag exists, the removal check is a no-op and you may skip "
+            "`--verify-removals` for this run only."
+        )
+    return True, tags[0], ""
+
+
+def load_snapshot_at_ref(ref: str, repo: Path = REPO_ROOT) -> dict[str, Any] | None:
+    """Read `tests/contract/public_surface.json` as it existed at `ref`. Returns
+    None if the file did not exist there.
+    """
+    rel = "tests/contract/public_surface.json"
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{rel}"],
+        cwd=str(repo),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return _normalize(json.loads(result.stdout))
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="check_public_surface",
+        description="Public-API stability gate for repo-context-hooks.",
+    )
+    p.add_argument(
+        "--verify-removals",
+        action="store_true",
+        help="Also diff against the snapshot at the previous release tag and require deprecation excuses.",
+    )
+    p.add_argument(
+        "--snapshot",
+        default=str(SNAPSHOT_PATH),
+        help="Path to the committed snapshot file.",
+    )
+    args = p.parse_args(argv)
+
+    snap_path = Path(args.snapshot)
+    snapshot = load_snapshot(snap_path)
+    current = introspect_surface()
+
+    drift = diff_surface(snapshot, current)
+    if drift:
+        print("PUBLIC SURFACE DRIFT -- snapshot does not match introspected package state.")
+        print("Edit `tests/contract/public_surface.json` in the same PR as the source change,")
+        print("or revert the source change. See docs/stability.md for the contract.\n")
+        for msg in drift:
+            print(f"  {msg}")
+        return 1
+
+    if not args.verify_removals:
+        return 0
+
+    ok, tag, diag = can_resolve_prior_tag()
+    if not ok:
+        print(f"PUBLIC SURFACE GATE: cannot run --verify-removals.\n  {diag}")
+        return 2
+
+    baseline = load_snapshot_at_ref(tag)
+    if baseline is None:
+        print(
+            f"No baseline `tests/contract/public_surface.json` at tag {tag}; "
+            "this is the first release of the gate. Treating as bootstrap (exit 0)."
+        )
+        return 0
+
+    removals = removed_symbols_vs_baseline(baseline, snapshot)
+    if not removals:
+        return 0
+
+    changelog_text = CHANGELOG_PATH.read_text(encoding="utf-8-sig")
+    deprecations = parse_changelog_deprecations(changelog_text)
+    removed_bullets = parse_changelog_removed_unreleased(changelog_text)
+
+    violations = []
+    for r in removals:
+        msg = explain_removal_violation(r, deprecations, removed_bullets)
+        if msg:
+            violations.append(msg)
+
+    if not violations:
+        return 0
+
+    print("PUBLIC SURFACE REMOVAL violates the deprecation contract.\n")
+    for v in violations:
+        print(v)
+        print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/contract/public_surface.json
+++ b/tests/contract/public_surface.json
@@ -1,0 +1,80 @@
+{
+  "_doc": "Source of truth for the repo-context-hooks public API. Edited in lockstep with repo_context_hooks/__init__.py, repo_context_hooks/cli.py, and the REPO_CONTEXT_HOOKS_* env-var readers. See docs/stability.md and docs/deprecation-policy.md. The CI gate scripts/check_public_surface.py compares the running package against this file and blocks unannounced removals.",
+  "schema_version": 1,
+  "all": [
+    "__version__"
+  ],
+  "console_scripts": [
+    "graphify",
+    "repo-context-hooks",
+    "repohandoff"
+  ],
+  "cli_commands": [
+    {
+      "name": "checkpoint",
+      "flags": ["--message", "--path"]
+    },
+    {
+      "name": "doctor",
+      "flags": ["--all-platforms", "--json", "--platform", "--repo-root"]
+    },
+    {
+      "name": "init",
+      "flags": ["--force", "--repo-root"]
+    },
+    {
+      "name": "install",
+      "flags": ["--also-repo-hooks", "--dedup", "--force", "--no-telemetry", "--platform", "--repo-root", "--skip-repo-hooks"]
+    },
+    {
+      "name": "measure",
+      "flags": ["--badge", "--badge-out", "--branches", "--clean-ghosts", "--experiment-dir", "--forecast", "--format", "--json", "--no-dry-run", "--open", "--output", "--redact", "--repo-root", "--snapshot-dir", "-o"]
+    },
+    {
+      "name": "platforms",
+      "flags": ["--json"]
+    },
+    {
+      "name": "recommend",
+      "flags": ["--json", "--limit", "--repo-root"]
+    },
+    {
+      "name": "telemetry",
+      "flags": [],
+      "subcommands": [
+        {"name": "disable", "flags": []},
+        {"name": "enable", "flags": ["--yes"]},
+        {"name": "preview", "flags": ["--repo-root"]},
+        {"name": "status", "flags": []}
+      ]
+    },
+    {
+      "name": "uninstall",
+      "flags": ["--platform"]
+    }
+  ],
+  "platform_choices": [
+    "claude",
+    "codex",
+    "cursor",
+    "kimi",
+    "lovable",
+    "ollama",
+    "openclaw",
+    "replit",
+    "windsurf"
+  ],
+  "env_vars": [
+    "REPO_CONTEXT_HOOKS_SAMPLE_RATE",
+    "REPO_CONTEXT_HOOKS_SESSION_ID",
+    "REPO_CONTEXT_HOOKS_TELEMETRY",
+    "REPO_CONTEXT_HOOKS_TELEMETRY_DIR"
+  ],
+  "file_locations": [
+    "%LOCALAPPDATA%\\repo-context-hooks\\events.jsonl",
+    "<repo>/.claude/settings.json",
+    "<repo>/specs/README.md#session-log",
+    "~/.cache/repo-context-hooks/events.jsonl",
+    "~/.claude/settings.json"
+  ]
+}

--- a/tests/contract/test_public_surface.py
+++ b/tests/contract/test_public_surface.py
@@ -1,0 +1,310 @@
+"""Public-API stability contract tests for `repo-context-hooks` (issue #72).
+
+These tests are the primary enforcement of the contract documented in
+`docs/stability.md` and `docs/deprecation-policy.md`. They run on every
+`pytest` invocation, so the contract travels with the package -- forks,
+monorepo vendors, and contributors without GitHub Actions are still
+protected. The CI gate (`scripts/check_public_surface.py --verify-removals`)
+adds removal-vs-prior-tag enforcement on top.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+import check_public_surface as gate  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Drift check -- the primary gate
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_matches_introspected_surface():
+    """The committed snapshot must match the running package, exactly.
+
+    If this fails, edit `tests/contract/public_surface.json` in the same PR
+    as the source change, or revert the source change. See docs/stability.md.
+    """
+    snapshot = gate.load_snapshot()
+    current = gate.introspect_surface()
+    drift = gate.diff_surface(snapshot, current)
+    assert drift == [], "Public-surface drift:\n" + "\n".join(f"  {m}" for m in drift)
+
+
+def test_every_name_in_dunder_all_is_importable():
+    import repo_context_hooks
+
+    for name in repo_context_hooks.__all__:
+        assert hasattr(repo_context_hooks, name), (
+            f"`__all__` lists `{name}` but `repo_context_hooks` does not expose it. "
+            "Either add the attribute or remove the entry from `__all__`."
+        )
+
+
+def test_no_undocumented_env_var():
+    """Every `REPO_CONTEXT_HOOKS_*` env var read by the package must be in
+    the snapshot. Catches the 'added a new env var, forgot to document it'
+    failure mode at PR time, not in the wild.
+    """
+    snapshot = gate.load_snapshot()
+    documented = set(snapshot.get("env_vars") or [])
+    found = gate._grep_env_vars(REPO_ROOT / "repo_context_hooks")
+    undocumented = found - documented
+    assert not undocumented, (
+        f"Undocumented public env vars referenced in source: {sorted(undocumented)}. "
+        "Add them to tests/contract/public_surface.json::env_vars and document them in "
+        "docs/stability.md and TELEMETRY.md."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drift check edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "snapshot,current,expected_drift",
+    [
+        pytest.param(
+            {"all": ["a"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []},
+            {"all": ["a"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []},
+            [],
+            id="empty-diff",
+        ),
+        pytest.param(
+            {"all": ["a"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []},
+            {"all": ["a", "b"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []},
+            ["[all] added 'b' to source but missing from snapshot."],
+            id="pure-addition-fails-drift",
+        ),
+        pytest.param(
+            {"all": ["a", "b"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []},
+            {"all": ["a"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []},
+            ["[all] removed 'b' from source but still in snapshot."],
+            id="silent-removal-fails-drift",
+        ),
+        pytest.param(
+            {"all": [], "console_scripts": [], "platform_choices": ["x", "y"], "env_vars": [], "cli_commands": []},
+            {"all": [], "console_scripts": [], "platform_choices": ["x"], "env_vars": [], "cli_commands": []},
+            ["[platform_choices] removed 'y' from source but still in snapshot."],
+            id="platform-choice-removal-detected",
+        ),
+        pytest.param(
+            {
+                "all": [], "console_scripts": [], "platform_choices": [], "env_vars": [],
+                "cli_commands": [{"name": "install", "flags": ["--platform"]}],
+            },
+            {
+                "all": [], "console_scripts": [], "platform_choices": [], "env_vars": [],
+                "cli_commands": [{"name": "install", "flags": []}],
+            },
+            ["[cli_commands] 'install': removed flag '--platform' still in snapshot."],
+            id="cli-flag-removal-detected",
+        ),
+    ],
+)
+def test_diff_surface_table(snapshot, current, expected_drift):
+    assert gate.diff_surface(snapshot, current) == expected_drift
+
+
+# ---------------------------------------------------------------------------
+# Removal-vs-baseline excuse logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "baseline,current,changelog,expected_violations",
+    [
+        pytest.param(
+            {"all": ["a"], "cli_commands": []},
+            {"all": ["a"], "cli_commands": []},
+            "## [Unreleased]\n",
+            0,
+            id="no-removal-no-violation",
+        ),
+        pytest.param(
+            {"all": ["a", "b"], "cli_commands": []},
+            {"all": ["a"], "cli_commands": []},
+            "## [Unreleased]\n",
+            1,
+            id="removal-with-no-deprecation-and-no-removed-entry-fails",
+        ),
+        pytest.param(
+            {"all": ["a", "b"], "cli_commands": []},
+            {"all": ["a"], "cli_commands": []},
+            "## [Unreleased]\n### Removed\n- `b` removed; was deprecated in 1.1.\n## [1.1.0] - 2026-05-01\n### Deprecated\n- `b` deprecated, use `a` instead.\n",
+            0,
+            id="removal-with-prior-deprecation-and-current-removed-passes",
+        ),
+        pytest.param(
+            {"all": ["a", "b"], "cli_commands": []},
+            {"all": ["a"], "cli_commands": []},
+            "## [Unreleased]\n## [1.1.0] - 2026-05-01\n### Deprecated\n- `b` deprecated.\n",
+            1,
+            id="prior-deprecation-but-no-current-removed-bullet-fails",
+        ),
+        pytest.param(
+            {"all": ["a", "b"], "cli_commands": []},
+            {"all": ["a"], "cli_commands": []},
+            "## [Unreleased]\n### Removed\n- `b` removed.\n",
+            1,
+            id="current-removed-but-no-prior-deprecation-fails",
+        ),
+        pytest.param(
+            {"cli_commands": [{"name": "install", "flags": ["--platform", "--legacy"]}]},
+            {"cli_commands": [{"name": "install", "flags": ["--platform"]}]},
+            "## [Unreleased]\n",
+            1,
+            id="cli-flag-removal-without-excuse-fails",
+        ),
+        pytest.param(
+            {"cli_commands": [{"name": "install", "flags": ["--platform", "--legacy"]}]},
+            {"cli_commands": [{"name": "install", "flags": ["--platform"]}]},
+            "## [Unreleased]\n### Removed\n- `--legacy` flag removed; deprecated in 1.1.\n## [1.1.0] - 2026-05-01\n### Deprecated\n- `--legacy` flag deprecated.\n",
+            0,
+            id="cli-flag-removal-with-deprecation-passes",
+        ),
+    ],
+)
+def test_removal_excuse_logic(baseline, current, changelog, expected_violations):
+    baseline_full = {
+        "all": baseline.get("all", []),
+        "console_scripts": [], "platform_choices": [], "env_vars": [],
+        "cli_commands": baseline.get("cli_commands", []),
+    }
+    current_full = {
+        "all": current.get("all", []),
+        "console_scripts": [], "platform_choices": [], "env_vars": [],
+        "cli_commands": current.get("cli_commands", []),
+    }
+    removals = gate.removed_symbols_vs_baseline(baseline_full, current_full)
+    deprecations = gate.parse_changelog_deprecations(changelog)
+    removed_bullets = gate.parse_changelog_removed_unreleased(changelog)
+    violations = [
+        gate.explain_removal_violation(r, deprecations, removed_bullets)
+        for r in removals
+    ]
+    actual = sum(1 for v in violations if v is not None)
+    assert actual == expected_violations, f"violations={violations}"
+
+
+def test_removed_then_readded_in_same_pr_is_not_flagged():
+    """The gate compares baseline-tag vs HEAD only. If a symbol is removed in
+    commit N and re-added in commit N+1 of the same branch, the net diff is
+    empty and the gate stays green.
+    """
+    baseline = {"all": ["a", "b"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []}
+    current = {"all": ["a", "b"], "console_scripts": [], "platform_choices": [], "env_vars": [], "cli_commands": []}
+    removals = gate.removed_symbols_vs_baseline(baseline, current)
+    assert removals == []
+
+
+# ---------------------------------------------------------------------------
+# CHANGELOG parser tolerance (Critic C: utf-8-sig + CRLF + mixed case)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param("﻿## [1.1.0]\n### Deprecated\n- `foo` deprecated.\n", id="utf-8-sig-bom"),
+        pytest.param("## [1.1.0]\r\n### Deprecated\r\n- `foo` deprecated.\r\n", id="crlf-line-endings"),
+        pytest.param("## [1.1.0]\n### deprecated\n- `foo` deprecated.\n", id="lowercase-heading"),
+        pytest.param("## [1.1.0]\n### DEPRECATED\n- `foo` deprecated.\n", id="uppercase-heading"),
+    ],
+)
+def test_changelog_parser_handles_quirky_input(raw):
+    deprecations = gate.parse_changelog_deprecations(raw)
+    flat = [b for bs in deprecations.values() for b in bs]
+    assert any("foo" in b for b in flat), f"Expected `foo` in parsed bullets; got {deprecations}"
+
+
+def test_unreleased_removed_section_isolated_from_release_versions():
+    """A `### Removed` block under a tagged version must not be confused with
+    one under `[Unreleased]`. Only `[Unreleased]`'s `### Removed` excuses a
+    removal in *this* PR.
+    """
+    changelog = textwrap.dedent(
+        """\
+        ## [Unreleased]
+        ## [1.0.0]
+        ### Removed
+        - `historic_thing` removed in 1.0.
+        """
+    )
+    bullets = gate.parse_changelog_removed_unreleased(changelog)
+    assert bullets == [], (
+        "parse_changelog_removed_unreleased must only return bullets under [Unreleased]; "
+        f"got {bullets}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DeprecationWarning surfaces to end users (Critic C2)
+# ---------------------------------------------------------------------------
+
+
+def test_deprecation_warning_surfaces_with_default_filters():
+    """If `pyproject.toml` ever globally silences DeprecationWarning, our entire
+    deprecation contract becomes a lie. Run a fresh subprocess with default
+    warning filters and confirm a DeprecationWarning hits stderr.
+    """
+    code = (
+        "import warnings; "
+        "warnings.warn('repo-context-hooks-deprecation-test', DeprecationWarning, stacklevel=1)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-W", "default", "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "repo-context-hooks-deprecation-test" in result.stderr, (
+        "DeprecationWarning did not surface with default warning filters. "
+        f"stderr={result.stderr!r}"
+    )
+
+
+def test_pyproject_does_not_globally_silence_deprecation_warnings():
+    """Hard-fail if a future `[tool.pytest.ini_options] filterwarnings` ever
+    silences DeprecationWarning unconditionally. Ignore-with-a-pattern is OK.
+    """
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8-sig")
+    bad_lines = [
+        ln for ln in pyproject_text.splitlines()
+        if "ignore::DeprecationWarning" in ln.replace(" ", "") and not ln.strip().startswith("#")
+    ]
+    assert not bad_lines, (
+        "Found unconditional `ignore::DeprecationWarning` in pyproject.toml. "
+        "This breaks the deprecation contract -- our DeprecationWarnings would never surface to users. "
+        f"Offending lines: {bad_lines}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap / shallow-clone safety (Critic C1, C5)
+# ---------------------------------------------------------------------------
+
+
+def test_can_resolve_prior_tag_self_reports():
+    """The helper must return an actionable diagnostic (not silently True) when
+    no tags are reachable.
+    """
+    ok, tag, diag = gate.can_resolve_prior_tag()
+    if not ok:
+        assert "fetch-depth" in diag.lower() or "git" in diag.lower(), diag
+    else:
+        assert tag, "ok=True but tag is empty"
+
+
+def test_load_snapshot_at_missing_ref_returns_none():
+    assert gate.load_snapshot_at_ref("definitely-not-a-real-ref-12345") is None


### PR DESCRIPTION
Closes #72.

## Summary

- Documents the v1.0 stability contract (`docs/stability.md`) and deprecation policy (`docs/deprecation-policy.md`); adds a `## Stability` section to README near the bottom; clusters both pages under a `Stability` group in mkdocs nav after `Telemetry Policy`.
- Locks the public surface into a machine-readable snapshot (`tests/contract/public_surface.json`) covering `__all__`, console scripts, every CLI subcommand + flag (incl. `telemetry` sub-subcommands), `--platform` choices, `REPO_CONTEXT_HOOKS_*` env vars, and stable file write locations.
- Adds a two-mode CI gate (`scripts/check_public_surface.py`): a drift check that runs as a pytest test so it travels with the package, plus a `--verify-removals` mode that diffs against the snapshot at the prior release tag and requires every removal to be excused by both a prior `### Deprecated` CHANGELOG bullet and a current `[Unreleased] ### Removed` bullet.

## Acceptance criteria (from issue #72)

- [x] `repo_context_hooks/__init__.py` declares an explicit `__all__` listing the public symbols (`["__version__"]`)
- [x] `docs/stability.md` documents Stable surfaces (CLI command names, documented flags, `REPO_CONTEXT_HOOKS_*` env vars, file locations of `events.jsonl` / `settings.json` writes) and Internal surfaces (`repo_context_hooks.platforms.*`, `repo_context_hooks.telemetry` Python imports, JSONL extras, exit-code values, log line text)
- [x] `docs/deprecation-policy.md` documents the one-MINOR-cycle `DeprecationWarning` rule, `### Deprecated` CHANGELOG flow, mandatory migration path, and per-context guidance for Python imports / CLI flags / subcommands / env vars / `--platform` choices
- [x] `README.md` adds `## Stability` section near the bottom, linking both new pages
- [x] `mkdocs.yml` adds both pages to nav as a `Stability` group right after `Telemetry Policy`
- [x] No code change beyond `__all__` in shipped runtime — gate + snapshot live under `scripts/` and `tests/`, neither shipped to PyPI

Issue text "no code change required beyond `__all__`" is honoured strictly. The user-added requirement (CI gate that fails the build if a public symbol is removed without going through the contract) is implemented as the `public-surface-guard` CI job + matching pytest tests.

## Self-review — non-negotiables that survived 3-critic consensus

The 3-critic strawman review surfaced one objection per critic that they would not budge on. All three are honoured:

1. **Critic A (Global-adoption): the gate must run as a `pytest` test, not only a CI workflow step — so the contract travels with the package and protects forks, monorepo vendoring, and contributors without GitHub Actions enabled.**
   Resolved by: `tests/contract/test_public_surface.py::test_snapshot_matches_introspected_surface` runs the drift check on every `pytest` invocation. The CI `public-surface-guard` job is a thin wrapper that adds `--verify-removals` against the prior release tag.

2. **Critic B (Repo-conventions): the CI guard must enforce ALL three pillars of the documented public surface (`__all__`, the nine CLI subcommands incl. flags + `--platform` choices, and `REPO_CONTEXT_HOOKS_*` env vars) — a doc that promises more than CI enforces is worse than no doc at all.**
   Resolved by: snapshot covers all three pillars (plus console scripts and file locations); gate diffs each. `test_no_undocumented_env_var` ALSO greps `repo_context_hooks/` source for `os.environ.get("REPO_CONTEXT_HOOKS_*")` / `os.getenv(...)` patterns and fails when a new env var is read but not snapshotted — closes the "added a new env var, forgot to document it" failure mode.

3. **Critic C (Failure-modes): the CI gate must run with `fetch-depth: 0` + `fetch-tags: true` and self-verify it can resolve the previous release tag, hard-failing the build with an actionable message if it cannot — silent green on a shallow clone is the failure mode that nullifies the entire deprecation contract.**
   Resolved by: `.github/workflows/ci.yml` `public-surface-guard` job sets `fetch-depth: 0` on `actions/checkout@v4`. `scripts/check_public_surface.py::can_resolve_prior_tag()` returns `(False, None, "No tags reachable. ... set fetch-depth: 0 ...")` and the gate exits with code 2 (distinct from drift exit 1) when it cannot resolve the prior tag.

## Test plan

A reviewer can verify locally with:

```bash
git checkout feat/stability-deprecation-contract
pip install -e ".[dev]"
python -m pytest tests/ -q                              # 372 tests, ≥80% cov gate
python scripts/check_public_surface.py                  # drift mode -> exit 0
python scripts/check_public_surface.py --verify-removals  # exit 0 (bootstrap, no snapshot at v0.6.0)
python -m pytest tests/contract/ -v                     # 25 contract-specific tests
```

Negative-path verification (try breaking the contract):

```bash
# 1. Drift detection: remove a flag from cli.py without updating snapshot
sed -i 's/"--no-telemetry",//' repo_context_hooks/cli.py
python scripts/check_public_surface.py
# Expected: exit 1, message "[cli_commands] 'install': removed flag '--no-telemetry' still in snapshot."
git checkout -- repo_context_hooks/cli.py

# 2. Drift detection: add a flag without updating snapshot
# (Requires a real flag add; alternatively edit snapshot to remove a flag and re-run gate.)

# 3. Removal-excuse bypass attempt: remove an env var from snapshot without CHANGELOG entry
# (Edit tests/contract/public_surface.json, remove an env var, run with --verify-removals once
#  v0.6.0 has a snapshot. Currently bootstraps because v0.6.0 predates this PR.)
```

CI verification on the PR will run:
- `test` matrix (4 Python × 2 OS = 8 cells), all 372 tests, ≥80% coverage gate
- `install-smoke-test` (Linux + Windows) — verifies CLI install still works end-to-end
- `platform-matrix` (9 platforms) — verifies every `--platform` choice still installs
- `public-surface-guard` (new) — drift + removal check with `fetch-depth: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)