### PR TITLE
fix(#75): pages.yml mike deploy — drop redundant alias on push-to-main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -78,20 +78,33 @@ jobs:
         run: mkdocs build --strict
 
       - name: Resolve docs version
+        # Two trigger paths:
+        #
+        #   - Push to main (no tag): rebuild the `latest` snapshot in place.
+        #     `mike` treats `latest` as a plain version slot here. No alias
+        #     update — passing `--update-aliases latest latest` errors out
+        #     with "duplicated version and alias" because mike rejects the
+        #     same name in both positions (observed on the first deploy
+        #     after PR #113, run 25224017603).
+        #
+        #   - Tag push (v1.0.0 etc.): snapshot the version AND repoint the
+        #     `latest` alias at it atomically.
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
+            DEPLOY_ARGS="--update-aliases ${VERSION} latest"
           else
             VERSION="latest"
+            DEPLOY_ARGS="${VERSION}"
           fi
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "DEPLOY_ARGS=${DEPLOY_ARGS}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy versioned snapshot via mike
-        # `--update-aliases` makes `latest` track this version atomically.
-        # The `latest` alias is what users see at the bare site URL once
-        # `mike set-default` has been run at least once below.
-        run: mike deploy --push --update-aliases "${{ steps.version.outputs.VERSION }}" latest
+        # On main: `mike deploy --push latest` (rebuilds the `latest` slot).
+        # On tag:  `mike deploy --push --update-aliases <version> latest`.
+        run: mike deploy --push ${{ steps.version.outputs.DEPLOY_ARGS }}
 
       - name: Set default alias to latest
         # Idempotent — safe to run on every deploy. Without it, the live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 <!-- none -->
 
 ### Fixed
+- `pages.yml` mike deploy: split the `--update-aliases` flag off the non-tag (push-to-main) path. Mike rejects `mike deploy --update-aliases latest latest` with "duplicated version and alias" when the version slot and the alias share a name. Tag pushes still pass `--update-aliases <version> latest`. Caught by the first post-#113 deploy (run 25224017603). (#75 follow-up)
 - `logging_setup._default_log_dir()` now wraps `Path.home()` in a `RuntimeError` guard with a `tempfile.gettempdir()` fallback. `Path.home()` raises `RuntimeError` (NOT `OSError`) on Windows SYSTEM accounts with unset `LOCALAPPDATA`, AWS Lambda layers, distroless containers, and hermetic Bazel sandboxes — exactly the global-adoption population v1.0 targets. The error fires before any handler can catch it, so without this fallback `configure_logging` crashed every subcommand including `doctor` itself. Phase 2 portability-axis review found this in PR #103 review. (#73)
 - `find_unreleased_changed_lines()` now accepts a `head_changelog` post-image so the gate detects bullets added BELOW an existing `## [Unreleased]` heading. Previously, `--unified=0` diffs without the heading line returned 0 — surfaced when the gate red-X'd its own PR (#94). Regression test pins the exact diff shape. (#76)
 - `tests/conftest.py` env-isolation list previously missed `REPO_CONTEXT_HOOKS_TELEMETRY_DIR`; switched to a `startswith()` glob that future-proofs every Wave 2/3 env var.


### PR DESCRIPTION
## Summary

Fixes the `Deploy docs to GitHub Pages` failure on the main branch (run [25224017603](https://github.com/narendranathe/repo-context-hooks/actions/runs/25224017603)) that fired right after PR #113 merged.

## Root cause

`pages.yml` ran:

```bash
mike deploy --push --update-aliases "latest" latest
```

Mike rejects this with `error: duplicated version and alias` because the same name appears as both the version slot and the alias target. On a tag push (e.g. `v1.0.0`) the command was `mike deploy --push --update-aliases 1.0.0 latest` — fine — but on a plain push to main the version resolved to `latest`, collapsing both arguments to the same name.

## Fix

Split the deploy invocation by trigger inside the existing `Resolve docs version` step:

| Trigger | Command |
|---|---|
| Push to main | `mike deploy --push latest` (rebuilds `latest` slot, no alias work) |
| Tag push (`v*`) | `mike deploy --push --update-aliases <version> latest` (snapshot + repoint alias) |

The downstream `mike set-default --push latest` step is idempotent and unchanged.

## Acceptance criteria

- [x] Workflow runs `mike deploy --push latest` (without `--update-aliases`) on push to main
- [x] Workflow still runs `mike deploy --push --update-aliases <version> latest` on tag pushes
- [x] CHANGELOG `[Unreleased] / Fixed` bullet added
- [ ] Workflow goes green when this PR's merge to main re-fires `pages.yml`

## Test plan

```bash
# Confirm the YAML still parses and the new conditional renders correctly.
# The actual mike deploy can only be tested by merging — the workflow runs
# only on push to main / tag, not on PR.
yamllint .github/workflows/pages.yml
```

After merge, watch the Actions tab. Expected timeline:
1. Deploy job starts (~10s after merge).
2. `pip install -e ".[docs]"` (~30s).
3. `mkdocs build --strict` clean (~5s).
4. `mike deploy --push latest` succeeds and pushes to gh-pages.
5. `mike set-default --push latest` succeeds (idempotent).
6. https://narendranathe.github.io/repo-context-hooks/ shows the new versioned site with troubleshooting + cli-reference pages and the version selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
