### PR TITLE
fix(release): unblock v1.0.0 — TestPyPI sigstore bundles + mike alias collision

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -78,31 +78,52 @@ jobs:
         run: mkdocs build --strict
 
       - name: Resolve docs version
-        # Two trigger paths:
+        # Two trigger paths, with `latest` reserved exclusively as an alias:
         #
-        #   - Push to main (no tag): rebuild the `latest` snapshot in place.
-        #     `mike` treats `latest` as a plain version slot here. No alias
-        #     update — passing `--update-aliases latest latest` errors out
-        #     with "duplicated version and alias" because mike rejects the
-        #     same name in both positions (observed on the first deploy
-        #     after PR #113, run 25224017603).
+        #   - Push to main (no tag): rebuild the `dev` snapshot. `dev` is
+        #     a plain version slot — the tip-of-main preview. The `latest`
+        #     name is NEVER deployed as a version slot, so it can serve
+        #     purely as an alias to whatever the most recent tag is.
         #
         #   - Tag push (v1.0.0 etc.): snapshot the version AND repoint the
-        #     `latest` alias at it atomically.
+        #     `latest` alias at it atomically. `--update-aliases` is safe
+        #     here because `latest` is always an alias, never a version.
+        #
+        # Earlier deploys (pre-v1.0.0) created a `latest` version slot.
+        # The `mike delete latest` step below cleans that up idempotently
+        # so the alias reassignment can proceed. After v1.0.0 ships, the
+        # delete is a no-op every run.
+        #
+        # History: the previous design deployed `latest` as a version slot
+        # on main pushes. The v1.0.0 tag deploy (run 25242241516) failed
+        # with `error: alias 'latest' already specified as a version`
+        # because mike forbids reusing a name as both. This rename to
+        # `dev` resolves that permanently.
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
             DEPLOY_ARGS="--update-aliases ${VERSION} latest"
           else
-            VERSION="latest"
+            VERSION="dev"
             DEPLOY_ARGS="${VERSION}"
           fi
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "DEPLOY_ARGS=${DEPLOY_ARGS}" >> "$GITHUB_OUTPUT"
 
+      - name: Clean up legacy 'latest' version slot (idempotent)
+        # One-time cleanup: the pre-v1.0.0 workflow deployed a `latest`
+        # version slot, which now blocks `--update-aliases ... latest` on
+        # tag pushes. `mike delete` is idempotent — after the first
+        # successful run on the canonical repo, subsequent runs find no
+        # `latest` version slot and exit cleanly. The `|| true` guard
+        # tolerates the post-cleanup steady state without failing CI.
+        run: |
+          mike delete --push latest 2>/dev/null || \
+            echo "no legacy 'latest' version to delete (steady state)"
+
       - name: Deploy versioned snapshot via mike
-        # On main: `mike deploy --push latest` (rebuilds the `latest` slot).
+        # On main: `mike deploy --push dev` (rebuilds the `dev` slot).
         # On tag:  `mike deploy --push --update-aliases <version> latest`.
         run: mike deploy --push ${{ steps.version.outputs.DEPLOY_ARGS }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,18 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Move sigstore bundles out of dist/ before TestPyPI publish
+        # `pypa/gh-action-pypi-publish` invokes twine which scans the entire
+        # dist/ directory and rejects `*.sigstore.json` as "Unknown
+        # distribution format" — observed on the v1.0.0 tag deploy
+        # (run 25242241509). TestPyPI does not store PEP 740 attestations
+        # (only PyPI does), so the bundles are not useful here. Move them
+        # aside; they remain in the artifact for the PyPI step below to use.
+        run: |
+          mkdir -p sigstore-bundles
+          mv dist/*.sigstore.json sigstore-bundles/ 2>/dev/null || true
+          ls -la dist/
+
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ All notable changes to this project will be documented in this file.
 <!-- none -->
 
 ### Fixed
-<!-- none -->
+- `publish.yml`: TestPyPI publish step now moves `*.sigstore.json` files out of `dist/` before invoking `pypa/gh-action-pypi-publish`. twine inspects the entire dist directory and rejects sigstore bundles as "Unknown distribution format" — observed on the v1.0.0 tag deploy (run 25242241509) when the bundles produced by `sigstore/gh-action-sigstore-python@v3.0.0` collided with the publish action. PyPI publishing still includes the bundles via `attestations: true` (the action handles them natively at the PyPI endpoint; TestPyPI does not store attestations anyway).
+- `pages.yml`: main-push deploys now write to a `dev` version slot rather than `latest`. `latest` is reserved exclusively as an alias, repointed atomically on tag pushes via `mike deploy --update-aliases <version> latest`. The previous design (deploy `latest` as a version slot on main) failed the v1.0.0 tag deploy (run 25242241516) with `error: alias 'latest' already specified as a version` — mike forbids name reuse. An idempotent `mike delete --push latest` step cleans up the legacy version slot once; subsequent runs no-op.
 
 ### Security
 <!-- none -->


### PR DESCRIPTION
## Summary

Two separable release-engineering bugs blocked the v1.0.0 tag deploys. Both fixed here in a single PR (small, additive changes to two workflow files + one CHANGELOG entry).

| Bug | Symptom | Fix |
|---|---|---|
| **publish.yml** | TestPyPI step rejected `*.sigstore.json` files alongside the wheel: `InvalidDistribution: Unknown distribution format` (run [25242241509](https://github.com/narendranathe/repo-context-hooks/actions/runs/25242241509)) | New step moves `*.sigstore.json` out of `dist/` before the TestPyPI publish. PyPI step still publishes the bundles via `attestations: true` (the action handles them natively at the PyPI endpoint; TestPyPI doesn't store PEP 740 attestations anyway). |
| **pages.yml** | mike refused `--update-aliases 1.0.0 latest`: `error: alias 'latest' already specified as a version` (run [25242241516](https://github.com/narendranathe/repo-context-hooks/actions/runs/25242241516)) | Rename main-push deploy slot from `latest` → `dev`. Reserve `latest` exclusively as an alias. Add an idempotent `mike delete --push latest` step to clean up the legacy version slot on the first run after this lands. |

## Root cause analysis

### publish.yml

`sigstore/gh-action-sigstore-python@v3.0.0` produces `<artifact>.sigstore.json` PEP 740 bundles in `dist/`. `pypa/gh-action-pypi-publish` (which wraps twine) walks the whole `dist/` directory and rejects any file whose extension isn't `.whl`, `.tar.gz`, or the legacy `.sigstore` (DSSE). The TestPyPI publish step was the first to fail because (a) it runs before the PyPI step, and (b) it doesn't pass `attestations: true` — TestPyPI doesn't store attestations, so there's no point.

The PyPI step has `attestations: true` and would have worked, but it never got there because TestPyPI was a `needs:` dependency.

### pages.yml

The previous workflow design treated `latest` as a version slot:

- main push → `mike deploy --push latest` (writes to a version named `latest`)
- tag push → `mike deploy --push --update-aliases <version> latest` (creates an alias named `latest`)

When the v1.0.0 tag fired, mike inspected `versions.json` and found `latest` already existed as a *version*. Aliases and versions share the same namespace in mike, so it refused to create the alias. Hence the failure.

The fix reserves `latest` exclusively as an alias by deploying main pushes to a new `dev` slot. After this PR lands, `versions.json` will look like:

```json
[
  {"version": "1.0.0", "aliases": ["latest"]},
  {"version": "dev",   "aliases": []}
]
```

…and the version selector in the docs nav will show "1.0.0 (latest)" and "dev". Subsequent tag deploys repoint the alias atomically.

## Acceptance criteria

- [x] `publish.yml` TestPyPI step no longer rejects sigstore bundles
- [x] `publish.yml` PyPI step still ships the bundles to PyPI via `attestations: true`
- [x] `pages.yml` main-push deploys to `dev`, not `latest`
- [x] `pages.yml` tag-push uses `--update-aliases <version> latest` and the alias is now valid (no collision)
- [x] One-time idempotent cleanup step removes the legacy `latest` version slot
- [x] CHANGELOG `[Unreleased] / Fixed` documents both bugs and their root causes

## What's next (post-merge)

After this lands on main:

1. **Move the v1.0.0 tag** to the new HEAD: `git tag -d v1.0.0 && git push origin :refs/tags/v1.0.0 && git tag -a v1.0.0 <new-sha> -m "v1.0.0" && git push origin v1.0.0`. (Or cut a fresh v1.0.1 if you prefer to leave the v1.0.0 tag immutable — your call as maintainer.)
2. The retag fires `pages.yml` (versioned snapshot at `/1.0.0/` with `latest` alias) and `publish.yml` (wheel + sdist + sigstore bundles to PyPI via Trusted Publisher OIDC).
3. Verify https://narendranathe.github.io/repo-context-hooks/1.0.0/ renders and `versions.json` shows the alias.
4. Verify https://pypi.org/project/repo-context-hooks/1.0.0/ shows the published artifact + Sigstore signature.

## Test plan

```bash
# YAML syntax sanity (no test of the workflow itself; that needs a real tag)
yamllint .github/workflows/pages.yml .github/workflows/publish.yml

# Verify the diff doesn't break local mkdocs build
pip install -e ".[docs]" && mkdocs build --strict
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
