### PR TITLE
docs(marketing): add phased launch drafts for v1.0.0 publicity push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Docs: example Session Log demonstrating the `checkpoint --message` workflow with 7 real v1.0.0 session decisions. Documents the canonical decision-capture pattern so adopters can see what a populated `## Session Log` looks like in practice.
 - `specs/README.md`: new "Product Positioning (USPs)" section. 10 falsifiable USPs (each pinned to a CLI command, file path, or metric) plus the defensible-angle note and the hard non-goals list. Source of truth for external positioning so future blog posts, README sections, and PR descriptions anchor to the same claims.
+- `marketing/posts/`: phased launch drafts for the v1.0.0 publicity push. Five posts (teaser, problem, solution+USPs, metrics, roadmap+contribute) each with Substack long-form + LinkedIn short-form variants, a posting schedule, a hashtag inventory, and per-post image-generation prompts. Drafts only; not part of the public stability contract.
 
 ### Changed
 - `README.md` and `specs/README.md` refreshed to reflect the v1.0.0 ship: install snippet, badge row, USP framing, and the closed PRD #68 + PRD #104 milestones. No code or behavior change.

--- a/marketing/posts/01-teaser.md
+++ b/marketing/posts/01-teaser.md
@@ -1,0 +1,75 @@
+# Post 1: Teaser / Origin Story
+
+**Posting slot:** Fri 2026-05-15 or Mon 2026-05-18, 9-10 AM CT
+**Theme:** Why I built this. Setup for the rest of the series.
+**CTA:** Subscribe to the Substack series + star the repo.
+
+---
+
+## Substack draft
+
+### Title
+
+Your coding agent has amnesia. I shipped the fix as an open-source Python package.
+
+### Body
+
+Every Claude Code user I know has hit this exact moment.
+
+You are 90 minutes deep into refactoring a service. The agent has finally figured out the test fixtures, the weird async pattern, the one helper that breaks if you import it before logging is configured. Then the context bar fills up. Claude compacts. You watch a useful, specific conversation collapse into a 200-word summary, and the agent comes back having forgotten which file you were even editing.
+
+I lost a whole afternoon to this last quarter. Not once. Twice.
+
+The Anthropic team has shipped two responses so far. CLAUDE.md gives you a static document the agent reads at startup. Auto Memory lets the agent itself decide what to remember, stored under `~/.claude/projects/<project>/memory/`. Both help. Neither survives the actual failure mode I keep hitting, which is: the agent forgets the **tactical** state — which branch I'm on, which 3 commits I shipped this session, what I tried that failed.
+
+I started writing hand-rolled `plan.md` + `context.md` + `tasks.md` files into every repo. It worked, but I was maintaining them manually, and every time I switched between Claude Code and Codex the contract was different.
+
+So I built `repo-context-hooks`.
+
+It is a 100% open-source Python package. One-line install:
+
+```
+pip install repo-context-hooks
+repo-context-hooks install --platform claude
+```
+
+It registers four hooks at the agent's lifecycle events — `SessionStart`, `PreCompact`, `PostCompact`, `SessionEnd` — and writes a deterministic workspace contract into `specs/README.md` in your repo. Not into `~/.claude/`. Into the repo. Where git can see it. Where your teammate can review it. Where `git blame` works.
+
+PreCompact fires, the hook writes branch + last 3 commits + working changes into `specs/README.md`. PostCompact fires, the agent reads that file and resumes with real tactical state, not a lossy LLM summary.
+
+Over the next two weeks I'm going to walk through:
+
+- **Tue 5/19:** Why context compaction is a deeper problem than it looks, with real data from anthropics/claude-code issue threads.
+- **Thu 5/21:** The 10 things that make `repo-context-hooks` different from CLAUDE.md, Auto Memory, claude-mem, and Context Mode.
+- **Tue 5/26:** Real before/after metrics — what `measure experiment` actually shows after a week of hooked sessions.
+- **Thu 5/28:** Where the roadmap is going (cross-workspace rollup is shipped; team rollup is next), and how to contribute.
+
+If you spend your days inside Claude Code or Codex on a real codebase, **subscribe** so you don't miss the rest. The first technical deep-dive lands Tuesday.
+
+Repo (star it if any of this resonates): https://github.com/narendranathe/repo-context-hooks
+
+---
+
+## LinkedIn draft
+
+I just open-sourced a Python package that fixes the single most expensive failure mode in Claude Code: context loss after compaction.
+
+If you've used Claude Code on a real codebase for more than 30 minutes, you've hit this. You are deep into a refactor, the agent has finally loaded the right mental model of the codebase, and then the context bar fills. Compaction fires. Two paragraphs of summary later, the agent is asking which file it was editing.
+
+CLAUDE.md and Auto Memory help but they store everything in `~/.claude/`. Machine-local. Not in git. Your teammates can't review what the agent "knows." Worse, the summary is LLM-generated — it drops branch state, the last 3 commits, what you tried that failed. The tactical context that matters most.
+
+`repo-context-hooks` flips the storage decision. It wires the four Anthropic lifecycle hooks (SessionStart / PreCompact / PostCompact / SessionEnd) and writes a deterministic workspace contract directly into your repo at `specs/README.md`. Diff-able. PR-reviewable. Survives compaction by design.
+
+One line to install:
+
+`pip install repo-context-hooks && repo-context-hooks install --platform claude`
+
+Zero runtime dependencies. Works across Claude Code, Codex, Cursor, Replit, Windsurf, Ollama, Kimi, Lovable, and OpenClaw with the same contract.
+
+Over the next two weeks I'll be publishing a 5-post series: the problem, the solution, the 10 USPs, real before/after metrics, and the roadmap.
+
+Star the repo if you want to follow along: https://github.com/narendranathe/repo-context-hooks
+
+What's the worst context loss moment you've hit with an AI coding assistant? Drop it in the comments.
+
+#ClaudeCode #AIAgents #DeveloperTools #OpenSource #AIEngineering #ContextEngineering #BuildInPublic

--- a/marketing/posts/02-problem.md
+++ b/marketing/posts/02-problem.md
@@ -1,0 +1,86 @@
+# Post 2: The Problem
+
+**Posting slot:** Tue 2026-05-19, 9-10 AM CT
+**Theme:** Why context compaction is a fundamental architectural problem, with data.
+**CTA:** Read the next post Thursday + open a GitHub discussion if you have a worse story.
+
+---
+
+## Substack draft
+
+### Title
+
+The 20-30% you lose every time Claude Code compacts
+
+### Body
+
+Claude Code's auto-compaction is one of the most-used features in any developer agent, and one of the least-discussed. Most people understand it as "the agent summarizes the conversation when it runs out of room." That framing is wrong in a way that matters.
+
+Compaction is not a summary. It is a **lossy re-encoding**. The original tokens are gone. What you get back is a model-generated narrative of what just happened. That narrative is biased toward "what happened" and away from "why" and "subtle details" — and one community-run measurement put the retention loss at 20-30% per compaction event (source at the bottom).
+
+Here is what the loss looks like in practice. I ran a real session last week, refactoring a FastAPI app. Pre-compact, the agent knew:
+
+- I was on branch `feat/clerk-auth-refactor`.
+- The last 3 commits were `1f9acd8`, `b054def`, `c755497`.
+- I had tried two approaches to the JWT verification and rejected the first because it caused a circular import.
+- The working tree had 4 modified files and 1 untracked spec.
+
+Post-compact, the agent still knew "we are refactoring auth." It had no idea about the branch, the commits, the circular import attempt, or the working tree. The next 10 minutes were me re-priming it.
+
+You can see this problem ratify itself in the Claude Code issue tracker. Issue [#13112](https://github.com/anthropics/claude-code/issues/13112) — "auto compact is the worst. every time it happens i feel like claude code has forgotten everything." Closed Not Planned. Issue [#43733](https://github.com/anthropics/claude-code/issues/43733) — community-filed request for a `PreCompact` hook so users can write their own state. The community wrote it themselves because the platform did not.
+
+Auto Memory helps a bit. It stores opinions about your project in `~/.claude/projects/<project>/memory/MEMORY.md` and reads the first 200 lines at session start. But Auto Memory is **non-deterministic by design** — the docs say Claude "decides what's worth remembering." When I read my own MEMORY.md, half the entries are anecdotes the model thought were interesting; none of them tell the next session what branch I was on.
+
+CLAUDE.md is the inverse — fully deterministic, but **static**. You write it by hand. It tells the agent who you are, not where you stopped.
+
+What is missing is a contract that is both **deterministic** (a hook wrote it on a fixed event, not the model when it felt like it) and **stateful** (it captures the tactical state of your last session, not just your preferences).
+
+That contract is what `repo-context-hooks` writes. Specifically:
+
+- On `PreCompact`, it appends branch + last 3 commits + changed files to `specs/README.md`.
+- On `SessionEnd`, it captures the same state plus an auto-commit snapshot.
+- On `SessionStart` and `PostCompact`, the next agent reads that file before doing anything else.
+
+It is in the repo. It is committed to git. Your teammate can read it. CI can read it. **The state belongs to you, not to `~/.claude/`.**
+
+Thursday I'll walk through the 10 things that make this design different from CLAUDE.md, Auto Memory, claude-mem, and Context Mode (the closest direct competitor). If you've hit a worse compaction story than mine, drop it in the GitHub discussions — I want to add the strongest ones to the post.
+
+Sources:
+- [BSWEN: Why Claude Loses Context After Compaction](https://docs.bswen.com/blog/2026-02-09-claude-context-loss-compaction/) — the 20-30% retention measurement
+- [Anthropic Auto Memory docs](https://code.claude.com/docs/en/memory) — "Claude decides what's worth remembering"
+- [anthropics/claude-code#13112](https://github.com/anthropics/claude-code/issues/13112)
+- [anthropics/claude-code#43733](https://github.com/anthropics/claude-code/issues/43733)
+
+---
+
+## LinkedIn draft
+
+Quick technical post about a failure mode every Claude Code user has hit.
+
+Auto-compaction isn't a summary. It's a lossy re-encoding. The original tokens are gone. What you get back is an LLM-generated narrative of what happened — and community measurements put the retention loss at 20-30% per event.
+
+What you lose first, every time:
+- Which branch you're on
+- The last 3 commits you shipped this session
+- The approach you just tried and rejected
+- The working-tree diff
+
+What survives:
+- "We're refactoring auth"
+
+That gap is the entire reason post-compact sessions feel like starting over. And it has been hit so many times that the GitHub issue is literally titled "auto compact is the worst" (anthropics/claude-code#13112 — closed Not Planned). Someone else opened anthropics/claude-code#43733 asking for a `PreCompact` hook the user could control.
+
+The community shipped the hook themselves. Anthropic exposed the lifecycle events; people are writing handlers.
+
+`repo-context-hooks` is one of those handlers. On `PreCompact`, it writes branch + last 3 commits + changed files into `specs/README.md` in your repo. Deterministic. Diff-able. Committed to git. The next session reads the file at `SessionStart` and resumes with real tactical state instead of a vibes summary.
+
+Auto Memory and CLAUDE.md don't cover this gap. Auto Memory is non-deterministic by design. CLAUDE.md is deterministic but static. The contract you actually need is deterministic AND stateful — and it has to live in the repo, not in `~/.claude/`, so your team can review it.
+
+Tomorrow's post (Thursday) is the 10-USP breakdown vs every competitor in the space.
+
+Try it: `pip install repo-context-hooks`
+Repo: https://github.com/narendranathe/repo-context-hooks
+
+What's the worst compaction story you've hit? I'm collecting the strongest ones for the next post.
+
+#ClaudeCode #AIEngineering #DeveloperTools #LLMOps #OpenSource #ContextEngineering #PromptEngineering

--- a/marketing/posts/03-solution-usps.md
+++ b/marketing/posts/03-solution-usps.md
@@ -1,0 +1,115 @@
+# Post 3: The Solution + 10 USPs
+
+**Posting slot:** Thu 2026-05-21, 9-10 AM CT
+**Theme:** What the product does, the 10 USPs, how to install, how to use, why unique.
+**CTA:** Install and run `measure experiment start` to capture your own baseline.
+
+---
+
+## Substack draft
+
+### Title
+
+`repo-context-hooks`: a git-tracked workspace contract for your AI coding agent
+
+### Body
+
+Tuesday I laid out the problem — Claude Code's compaction drops 20-30% of detail per event, Auto Memory is non-deterministic, CLAUDE.md is static. The gap is a contract that is deterministic AND stateful AND lives in your repo.
+
+This post is the solution and the 10 things that make it different.
+
+### What it does, in one sentence
+
+`repo-context-hooks` installs four Anthropic lifecycle hooks (`SessionStart` / `PreCompact` / `PostCompact` / `SessionEnd`) and maintains a git-tracked workspace contract in your repo so the next agent session resumes with real state instead of a lossy summary.
+
+### How to install
+
+```
+pip install repo-context-hooks
+repo-context-hooks install --platform claude
+repo-context-hooks doctor
+```
+
+That is the whole install. Zero runtime dependencies (`pyproject.toml` declares `dependencies = []`). `doctor` confirms the hooks are wired correctly. Auto-detect mode (no `--platform` flag) installs to every detected agent at once.
+
+### How to use it
+
+You don't. After install, the hooks fire on their own at the lifecycle events. Open Claude Code in any repo. The first time, it scaffolds `specs/README.md`, `UBIQUITOUS_LANGUAGE.md`, and an AUTO:REPO_CONTEXT block. Every subsequent session reads them at `SessionStart` and appends to them at `PreCompact` and `SessionEnd`.
+
+The optional manual surface is `checkpoint --message "..."` — call it when you want to capture a semantic decision the hooks can't infer (the "why," not the "what"). Decision goes under `## Session Log` in `specs/README.md`. Future-you and future-agent both read it.
+
+### Why developers should care — the 10 USPs
+
+1. **Your agent's memory lives in `git`, not `~/.claude/`.** `specs/README.md` and `UBIQUITOUS_LANGUAGE.md` are checked in, diff-able, PR-reviewable. Auto Memory, claude-mem, and Context Mode all store machine-local blobs no teammate can review.
+2. **Deterministic, not lossy.** `PreCompact` appends an exact snapshot: branch, last 3 commits, working changes. No LLM summarization in the loop.
+3. **Bound to the four Anthropic hook events.** `SessionStart` / `PreCompact` / `PostCompact` / `SessionEnd`. Wired automatically. Directly addresses the gap closed-as-Not-Planned in anthropics/claude-code#13112.
+4. **Cross-harness with one contract.** 9 platform adapters — Claude (native), Codex, Cursor, Replit, Windsurf, Ollama, Kimi, Lovable, OpenClaw. Same contract, different agent.
+5. **Self-measuring with public proof.** Every install produces `continuity_score`, `cold_start_time_saved_minutes`, `tokens_saved`, `cost_saved_usd`, and a three-color SVG badge auto-rendered to `docs/badge.svg`. Receipts, not vibes.
+6. **Before/after experiment mode.** `measure experiment start | finish` captures your baseline before installing hooks, then re-measures after a week. The delta is a redacted impact report you can paste into a PR, a LinkedIn post, or your manager's Slack.
+7. **Zero runtime dependencies. One-line install.** Already shown above. No venv hell, no transitive CVEs.
+8. **Privacy by design.** SHA-256 hashed repo IDs. No source, prompts, PR bodies, or filesystem inventory leaves your machine. `--no-telemetry` bakes opt-out into the hook command string itself so it survives shell restarts.
+9. **CI-ready operational tooling.** `doctor --all-platforms`, `recommend --json`, `verify`, `--dry-run`, `--clean-ghosts`, public-surface contract. Drops into a CI gate without a 50-line shell wrapper.
+10. **Supply-chain integrity by default.** GitHub Actions OIDC trusted publishing. Sigstore attestations. `gh attestation verify`. Dependabot. CodeQL. Installable inside enterprise procurement.
+
+### Why it's unique
+
+The unoccupied seam in this market is **repo-tracked, deterministic, lifecycle-bound** continuity. Every direct competitor breaks at least one of those:
+
+- **CLAUDE.md** — deterministic, repo-tracked. Not lifecycle-bound. Static.
+- **Auto Memory** — lifecycle-bound, deterministic in writes. Not repo-tracked (`~/.claude/`). Non-deterministic in *what* gets written.
+- **claude-mem** — lifecycle-bound, repo-aware. LLM-summarized (lossy). SQLite + chromadb, not git.
+- **Context Mode** — lifecycle-bound, multi-platform. Per-project SQLite blob, not in git, not reviewable.
+
+We are the only tool that puts a diff-able workspace contract in your repo and writes to it on a hook event. That is the seam.
+
+### What's next in the series
+
+- **Tue 5/26:** Real `measure experiment` deltas from a week of hooked sessions on a Python service.
+- **Thu 5/28:** Roadmap, contribution guide, and what I want feedback on.
+
+Try it today and run `measure experiment start` so you have a baseline ready when Tuesday's post drops:
+
+```
+pip install repo-context-hooks
+repo-context-hooks install --platform claude
+repo-context-hooks measure experiment start
+```
+
+Then go do your normal work for a few days.
+
+Repo: https://github.com/narendranathe/repo-context-hooks
+
+---
+
+## LinkedIn draft
+
+10 reasons developers should care about `repo-context-hooks` — the open-source Python package that fixes Claude Code's context loss after compaction.
+
+(Threading off Tuesday's post on why compaction drops 20-30% of detail per event.)
+
+1. Your agent's memory lives in `git`, not `~/.claude/`. PR-reviewable workspace contract.
+2. Deterministic snapshots — branch + last 3 commits + working changes. No LLM summarization.
+3. Wired to the four Anthropic lifecycle hooks: SessionStart / PreCompact / PostCompact / SessionEnd.
+4. Cross-harness — same contract works on Claude, Codex, Cursor, Replit, Windsurf, Ollama, Kimi, Lovable, OpenClaw.
+5. Self-measuring — every install emits continuity_score, cold_start_time_saved_minutes, tokens_saved, cost_saved_usd, and an SVG badge.
+6. Before/after experiment mode — `measure experiment start | finish` proves the impact with a redacted shareable report.
+7. Zero runtime dependencies. One-line install: `pip install repo-context-hooks`.
+8. Privacy by design — SHA-256 hashed repo IDs, no source/prompts/PR bodies collected, no remote collector.
+9. CI-ready — `doctor`, `verify`, `--dry-run`, public-surface contract. Drops into a gate.
+10. Supply-chain hardened — OIDC trusted publishing, Sigstore, attestations, Dependabot, CodeQL.
+
+The unique seam: every competitor (CLAUDE.md, Auto Memory, claude-mem, Context Mode) breaks at least one of {repo-tracked, deterministic, lifecycle-bound}. We are the only tool that hits all three.
+
+Install + start a baseline experiment right now so you have data ready for next week's post:
+
+```
+pip install repo-context-hooks
+repo-context-hooks install --platform claude
+repo-context-hooks measure experiment start
+```
+
+Repo: https://github.com/narendranathe/repo-context-hooks
+
+Which of these 10 USPs matters most to your workflow? Curious where the priority sits for working devs vs platform teams.
+
+#ClaudeCode #AIAgents #DeveloperTools #OpenSource #LLMOps #PythonDev #DevTooling #AIEngineering

--- a/marketing/posts/04-metrics-use-cases.md
+++ b/marketing/posts/04-metrics-use-cases.md
@@ -1,0 +1,113 @@
+# Post 4: Use Cases + Measurable Impact
+
+**Posting slot:** Tue 2026-05-26, 9-10 AM CT
+**Theme:** How devs are using it, real before/after metrics, three concrete workflows.
+**CTA:** Run `measure export` and share your own delta in the comments.
+
+> **Pre-post checklist (do this Mon 5/25):**
+> 1. Run `repo-context-hooks measure experiment finish` on the baseline you started 5/21.
+> 2. Capture the redacted output of `repo-context-hooks measure export --format markdown` and paste real numbers into the placeholders below (marked `[REPLACE]`).
+> 3. Drop in 2 screenshots: the SVG badge before / after, and the dashboard at `docs/monitoring/`.
+
+---
+
+## Substack draft
+
+### Title
+
+What happens when you actually run `repo-context-hooks` for a week — receipts
+
+### Body
+
+Last Thursday I asked you to install `repo-context-hooks`, run `measure experiment start`, then go do your normal work. Today I'm going to walk through what mine looked like over the past week and how to read the output.
+
+### My setup
+
+- One active repo: `autoapply-ai` (a FastAPI + Chrome MV3 + Postgres + Redis stack).
+- Claude Code primary, Codex as a secondary harness for parallel feature work.
+- Average session length: 90 minutes.
+- Auto-compaction events: roughly 4 per day.
+
+### The headline numbers
+
+After 7 days of normal work, `measure export --format markdown` returned:
+
+```
+Continuity score:              [REPLACE]    (baseline: [REPLACE])
+Lifecycle coverage:            [REPLACE]%   (target >= 75%)
+Cold starts prevented:         [REPLACE]
+cold_start_time_saved_minutes: [REPLACE]
+Tokens saved (est.):           [REPLACE]
+Cost saved (est., USD):        $[REPLACE]
+Week-1 uplift:                 +[REPLACE]
+```
+
+The two metrics I care about most:
+
+- **`cold_start_time_saved_minutes`** — this counts `PostCompact` events and multiplies by 5 minutes, the conservative estimate of how long it would have taken to re-prime the agent from scratch. Mine landed at `[REPLACE]` minutes over the week.
+- **Week-1 uplift** — the day-7 continuity score minus day-0. Anything positive means the contract is getting denser. Mine was `+[REPLACE]`.
+
+### Three concrete use cases
+
+**1. Long refactors that span days.** I'm in the middle of a Clerk auth refactor on `autoapply-ai`. The session log in `specs/README.md` now contains 7 timestamped decision entries — "rejected approach X because of circular import," "chose Z because of the IPv4 pooler constraint on Fly.io." Next session walks in already knowing which doors are closed.
+
+**2. Switching between Claude Code and Codex on the same repo.** Both agents read the same `specs/README.md`. I no longer re-explain "we already decided to use the session-mode pooler" every time I switch harness.
+
+**3. Onboarding a teammate.** This one surprised me. A friend cloned the repo to look at an issue. Their Claude Code session at `SessionStart` read my workspace contract and immediately knew the project shape, the open questions, and the next action. Zero context-loading prompt from them.
+
+### How to read the dashboard
+
+`repo-context-hooks measure --open` launches a local HTML dashboard at `docs/monitoring/index.html`. Three columns matter:
+
+- **Lifecycle coverage** — what % of expected hook events actually fired. Below 25% (red badge) means your install is broken. Run `doctor`.
+- **Cold starts prevented** — how many `PostCompact` reload events happened. Higher is better (means compaction fired but you didn't lose context).
+- **Avg session duration** — drift here points at workflow changes, not tool problems.
+
+### How to share your own numbers
+
+`measure export --format markdown -o impact.md` produces a redacted impact report you can paste anywhere. Repo names get redacted to short hashes, timestamps stay, scores stay. Paste it into a PR description when you ship the install, into a LinkedIn post, into your weekly update to your manager.
+
+### What I want from you
+
+If you've been running the hooks for a week, drop your `cost_saved_usd` and lifecycle_coverage % in the comments. The strongest deltas will go into Thursday's roadmap post, with credit and links.
+
+Thursday: roadmap (cross-workspace rollup is shipped, team rollup is next), how to contribute, what feedback I want.
+
+Repo: https://github.com/narendranathe/repo-context-hooks
+
+---
+
+## LinkedIn draft
+
+One week of `repo-context-hooks` running on my main repo. Receipts below.
+
+I asked you all last Thursday to install + start an `experiment` baseline. Here's mine after 7 days of normal Claude Code + Codex work on a FastAPI + Postgres + Chrome MV3 stack:
+
+```
+Continuity score:              [REPLACE]
+Lifecycle coverage:            [REPLACE]%
+Cold starts prevented:         [REPLACE]
+Time saved (cold starts):      [REPLACE] min
+Tokens saved:                  ~[REPLACE]
+Cost saved (est.):             $[REPLACE]
+Week-1 uplift:                 +[REPLACE]
+```
+
+The metric I care about most: `cold_start_time_saved_minutes`. It counts every `PostCompact` event and multiplies by 5 min — the conservative estimate of how long it would take to re-prime the agent if compaction had wiped my context. Mine landed at `[REPLACE]` over the week.
+
+Three places this paid off most:
+
+1) Long refactors that span days. The `## Session Log` in specs/README.md now has 7 decision entries with rationale ("rejected X because circular import," "chose Z because of the IPv4 pooler"). Future-me walks in knowing which doors are closed.
+
+2) Switching between Claude Code and Codex on the same repo. Both read the same contract. No re-explaining what we already decided.
+
+3) Onboarding a teammate. A friend cloned the repo, Claude Code at SessionStart read the contract, they had zero ramp time on what the project even was.
+
+If you installed it last week, run `measure export --format markdown` and post your delta. Best ones go into Thursday's roadmap post.
+
+Install if you haven't: `pip install repo-context-hooks`
+Repo: https://github.com/narendranathe/repo-context-hooks
+
+What's the biggest "I have to re-explain this to the agent" moment that this would have saved you?
+
+#ClaudeCode #DeveloperTools #AIAgents #LLMOps #BuildInPublic #AIEngineering #OpenSource #PythonDev

--- a/marketing/posts/05-roadmap-contribute.md
+++ b/marketing/posts/05-roadmap-contribute.md
@@ -1,0 +1,119 @@
+# Post 5: Roadmap + How to Contribute
+
+**Posting slot:** Thu 2026-05-28, 9-10 AM CT
+**Theme:** What's shipped, what's next, how to contribute, what feedback is most useful.
+**CTA:** Open an issue / discussion. Recruit 5 contributors.
+
+---
+
+## Substack draft
+
+### Title
+
+The road to `repo-context-hooks` 1.1 — and the 3 things I want your help on
+
+### Body
+
+Wrapping the launch series with where the project stands, what's coming, and the specific places I would love community contribution.
+
+### What's already shipped (v1.0.0)
+
+The v1.0 release in early May was a 10-vertical-slice production-readiness push. Specifically:
+
+- **Community health** — `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, issue + PR templates.
+- **Supply chain** — Sigstore signing, Dependabot, SHA-pinned actions, CodeQL workflow, OIDC trusted publishing.
+- **Coverage gate** — 85% line coverage via Hypothesis property tests on the critical paths.
+- **Stability contract** — explicit `__all__`, `tests/contract/public_surface.json` snapshot, public-surface CI gate.
+- **Self-observability** — `repo_context_hooks.logging_setup` module, global `--debug`, `doctor` last-error surface.
+- **Install/uninstall UX** — `verify` command, `--dry-run` on install/uninstall.
+- **Docs depth** — troubleshooting, mkdocs-click CLI reference, `mike` versioned docs, copy-paste quickstart.
+- **Release engineering** — changelog gate, auto-populated GH Release notes, richer `--version`.
+- **Governance** — `NOTICE`, zero-deps callout, maintainer-status section.
+- **Cross-workspace rollup** — `measure --all-repos` walks every workspace under the telemetry base and prints fleet-level numbers.
+
+Versioned docs site: https://narendranathe.github.io/repo-context-hooks/latest/
+
+### What's next (v1.1 and beyond)
+
+Live issues, ordered by my current priority:
+
+- **#124 / PR #125** — Bug: AUTO:REPO_CONTEXT block clobber on every SessionStart. Confirmed root cause in `extract_repo_summary`. Merge candidate this week.
+- **#126** — Auto decision-capture at Stop / PreCompact. The current `checkpoint --message` flow is manual — adopters skip it, semantic decisions never persist. Working on a hook-injected prompt that nudges the agent to call `checkpoint` at the right moments.
+- **#75** — Docs depth round 2: more troubleshooting recipes, an asciinema demo, more `mike` aliases.
+- **#23** — Guided before/after experiment flow improvements. The `measure experiment` command works; it can be made more conversational.
+- **#26** — Team rollup server. Today `measure --all-repos` is single-machine. v1.1 will optionally accept a consented remote endpoint for team-level fleet rollup. Hard non-goal: a hosted dashboard. The endpoint stays open spec, run-it-yourself.
+
+### Where I want community help
+
+Three concrete asks. All have open issues you can pick up.
+
+**1. Field-test the partial-tier adapters.** Claude is `native`. Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, and Kimi are `partial`. The `partial` tier scaffolds the right repo surface but does not wire lifecycle hooks because those platforms don't expose them yet. If you primarily use one of those agents, file issues with concrete examples of what "lifecycle parity" would look like for it. Issue label: `platform-parity`.
+
+**2. Better default workspace contract templates.** `specs/README.md` and `UBIQUITOUS_LANGUAGE.md` get scaffolded with sensible defaults, but every team has a different shape. PRs welcome with alternative templates for: data eng (dbt / Airflow / Spark stacks), ML training loops, Chrome extensions, Rust crates. Issue label: `template-pack`.
+
+**3. Honest before/after data.** Run `measure experiment start | finish` for a week and post the JSON output (the redacted form is safe to share). I want to validate the `cold_start_time_saved_minutes` heuristic against real adoption. If the 5-minute constant is wrong, I want to know.
+
+### Ideas on making it better
+
+Open the discussions tab: https://github.com/narendranathe/repo-context-hooks/discussions
+
+Topics I would love thoughts on:
+
+- Should `checkpoint --message` be auto-triggered? If yes, what's the right hook signal?
+- Is the `docs/badge.svg` worth the build cost, or does no one look at it?
+- Would you pay for a hosted team-rollup endpoint, or is self-hosted the only acceptable model?
+- What other agents should get a `partial` adapter? Aider? Continue.dev? Roo Code?
+
+### How to contribute
+
+`CONTRIBUTING.md` covers the basics. Quick orientation:
+
+- Stack: Python 3.9-3.13, zero runtime dependencies, `pyproject.toml`, Hypothesis property tests.
+- 85% coverage gate, stability contract via `tests/contract/public_surface.json`.
+- Every PR adds a CHANGELOG entry under `[Unreleased]`.
+- I respond to issues and PRs within 48 hours on weekdays (best-effort; this is a single-maintainer project).
+
+If you've made it through all 5 posts in this series, you understand the product better than most contributors will when they first land. **Star the repo, open one issue, and tell me one thing you'd change.** That's the highest-signal contribution.
+
+Repo: https://github.com/narendranathe/repo-context-hooks
+Docs: https://narendranathe.github.io/repo-context-hooks/latest/
+Discussions: https://github.com/narendranathe/repo-context-hooks/discussions
+PyPI: https://pypi.org/project/repo-context-hooks/
+
+Thanks for reading the series. Next post will probably be a deep dive on the v1.1 hook auto-trigger design — drop a comment if there's a specific angle you want covered.
+
+---
+
+## LinkedIn draft
+
+Closing out the 5-post `repo-context-hooks` launch series.
+
+What's shipped in v1.0:
+- 10-slice production-readiness push (community health, supply chain, stability contract, self-observability, install UX, docs depth, release engineering, governance, cross-workspace rollup)
+- 85% test coverage gate via Hypothesis property tests
+- OIDC trusted publishing + Sigstore attestations
+- 9 platform adapters (Claude native, 8 partial)
+- Versioned docs site at narendranathe.github.io/repo-context-hooks/latest
+
+What I'm working on next:
+- Auto decision-capture (#126) so `checkpoint --message` fires from a hook instead of being manual
+- AUTO:REPO_CONTEXT clobber bug (PR #125, merge candidate this week)
+- Team rollup endpoint (#26) — single-machine `measure --all-repos` is shipped; v1.1 adds optional consented endpoint
+
+Three concrete asks for the community:
+
+1. **Field-test the partial-tier adapters** (Cursor, Codex, Replit, Windsurf, Lovable, OpenClaw, Ollama, Kimi). If you use one of these primarily, open an issue with what "lifecycle parity" would look like. Label: `platform-parity`.
+
+2. **Contribute workspace contract templates** for your stack (data eng, ML training, Chrome MV3, Rust crates). Label: `template-pack`.
+
+3. **Share honest before/after data** from a week of running the hooks. I want to validate the `cold_start_time_saved_minutes` heuristic against real adoption.
+
+If you've followed the whole series, you know the product better than most first-time contributors. The single highest-signal thing you can do: **star the repo, open one issue, tell me one thing you'd change.**
+
+Repo: https://github.com/narendranathe/repo-context-hooks
+Docs: https://narendranathe.github.io/repo-context-hooks/latest/
+Discussions: https://github.com/narendranathe/repo-context-hooks/discussions
+
+What would you build on top of a deterministic, repo-tracked workspace contract? Curious where the community wants this to go.
+
+#ClaudeCode #OpenSource #DeveloperTools #AIAgents #BuildInPublic #PythonDev #LLMOps #ContextEngineering #AIEngineering

--- a/marketing/posts/IMAGE-PROMPTS.md
+++ b/marketing/posts/IMAGE-PROMPTS.md
@@ -1,0 +1,147 @@
+# Image Generation Prompts for the Launch Series
+
+Paste these into Midjourney, DALL-E 3, ChatGPT image-gen, Imagen, Stable Diffusion (SDXL/Flux), or any image agent. Each post has:
+
+- **Hero image** — top of the Substack post + LinkedIn share card (wide, 1200x628 or 1.91:1)
+- **Supporting visual** — mid-post diagram or detail shot (square, 1:1)
+
+## Global style anchors (paste at the end of every prompt)
+
+```
+Style: modern developer tooling brand aesthetic. Clean, geometric, slightly editorial. Inspired by Stripe Press covers, GitHub blog hero images, Linear product shots, and Increment magazine. Color palette: soft slate-blue background (#0F172A or #1E293B), warm off-white text (#F8FAFC), one accent color (electric green #4ADE80 or warm amber #F59E0B). High contrast type if any. No stock-photo people. No corporate handshakes. No glowing neural networks. No fake brand logos. Negative prompt: cluttered, busy, generic AI art, blurry, low-contrast, lens flare, photorealistic AI portraits, fake brand marks, watermark, signature.
+```
+
+## Standing technical constraints (always include)
+
+- **Aspect ratio**: hero = 16:9 or 1.91:1 (LinkedIn share card 1200x628). Supporting = 1:1.
+- **No text in image unless explicitly part of prompt** — easier to add real legible text later in Figma / Canva.
+- **No fake logos** — if a logo is wanted, leave blank space for the user to overlay the real `repo-context-hooks` mark.
+
+---
+
+## Post 1: Teaser — "Your coding agent has amnesia"
+
+### Hero (1.91:1)
+
+```
+A stylized minimalist illustration of a developer's workspace at the moment of context loss. Foreground: a clean code editor window in dark mode showing a half-finished function, three of its variable names already fading into the background. Behind the editor, a translucent ghost-like silhouette of an AI agent (geometric, not humanoid — think a glowing wireframe cube or sphere) is dissolving into a stream of fragmented memory tiles drifting away into the void. To the right side of the frame, a single small Git branch icon stays sharp and in-focus, hinting that the fix is in the repo, not in the agent's head. Composition: rule-of-thirds, left two-thirds is "loss," right one-third is "what survives." Mood: melancholic but hopeful — not horror.
+
+[paste global style anchors here]
+```
+
+### Supporting (1:1)
+
+```
+Close-up macro of a single line in a terminal: `pip install repo-context-hooks` rendered in crisp monospace font on a dark slate background. The cursor blinks one character past the line. Subtle film grain. The bottom 20% of the frame has a faint, semi-transparent horizontal git commit graph (three nodes connected by lines) as background texture. No other UI chrome.
+
+[paste global style anchors here]
+```
+
+---
+
+## Post 2: The Problem — "The 20-30% you lose every compaction"
+
+### Hero (1.91:1)
+
+```
+A flat, infographic-style illustration showing the moment of context compaction as a literal data-compression event. Left side: a tall vertical stack of 30+ small, distinct colorful tiles labeled with subtle code icons (a branch icon, a commit hash, a file name, a diff hunk). Center: an arrow pointing right through a stylized prism or funnel labeled "compaction." Right side: a much shorter stack of only 6-8 dull, beige tiles — labeled "summary." The difference in volume and saturation is the entire visual punchline: 70% of the original information is missing. Above the prism, a small floating number "−25%" rendered in the accent color (electric green or warm amber). Style: editorial infographic, think New York Times feature or FiveThirtyEight visualization.
+
+[paste global style anchors here]
+```
+
+### Supporting (1:1)
+
+```
+Side-by-side comparison of two file icons. Left: a file labeled `~/.claude/MEMORY.md` rendered with a small "machine-local" padlock badge, faintly grayed-out, sitting on a single laptop silhouette. Right: a file labeled `specs/README.md` rendered with a bright Git branch icon, vibrant, connected by short lines to three small silhouettes representing teammates. Below the two files, a thin horizontal divider labeled "the seam." Composition: balanced halves, left feels cold, right feels collaborative.
+
+[paste global style anchors here]
+```
+
+---
+
+## Post 3: The Solution — "10 USPs"
+
+### Hero (1.91:1)
+
+```
+A clean, isometric illustration of a workspace contract as a literal document floating over an open git repository. The document itself is rendered as a stack of three translucent layered cards labeled (top to bottom) `specs/README.md`, `UBIQUITOUS_LANGUAGE.md`, `CHANGELOG.md`. Four glowing lines flow into the top of the stack from four labeled circular nodes positioned in a horizontal row above: SessionStart, PreCompact, PostCompact, SessionEnd. The git repository underneath is rendered as a stylized 3D folder with a faint commit graph wrapping around it. To the right, a small monitoring dashboard panel shows three sparkline-style charts in the accent color. Composition: centered, balanced, technical-blueprint feel.
+
+[paste global style anchors here]
+```
+
+### Supporting (1:1)
+
+```
+A clean numbered list visualization. Background: dark slate. Foreground: ten small geometric icons arranged in a 5x2 grid, each in its own card. Icons are abstract glyphs representing the 10 USPs — a git branch (repo-native), a perfect circle (deterministic), four chained nodes (lifecycle hooks), nine connected dots (cross-harness), a small bar chart (self-measuring), a stopwatch with a delta arrow (experiment mode), a single download arrow (one-line install), a padlock (privacy), a check shield (CI-ready), a verified seal (supply-chain). No text labels on the icons. Each card has a subtle accent-colored border. Mood: like a feature grid on a Stripe or Linear marketing page.
+
+[paste global style anchors here]
+```
+
+---
+
+## Post 4: Use Cases + Measurable Impact — "Receipts"
+
+### Hero (1.91:1)
+
+```
+A photo-realistic close-up of a developer's dual-monitor setup in a dim room. Left monitor: a clean modern monitoring dashboard with three vivid chart cards — a green upward-trending line chart, a horizontal bar chart in warm amber, and a circular progress ring at roughly 87%. Right monitor: a terminal with a faintly visible block of metrics output (do not render legible specific numbers — keep it impressionistic). Foreground: a coffee mug, slightly out of focus, sitting beside a small mechanical keyboard. Mood: confident, late-evening, the moment when the data tells a story. Lighting: cool blue from the monitors, warm desk lamp on the right edge. Composition: 60% left monitor (the chart story), 40% right monitor + desk.
+
+[paste global style anchors here]
+```
+
+### Supporting (1:1)
+
+```
+An abstract before-and-after split panel. Left half (labeled BEFORE in small caps at the top): a chaotic tangle of intersecting thin lines in a muted gray, with three small "X" marks scattered through it representing failed approaches. Right half (labeled AFTER in small caps): the same lines reorganized into a clean ascending staircase pattern in the accent color, with three small green check marks where the X marks were. A thin vertical line down the center separates the two halves. Below the split, a single horizontal bar labeled "Week-1 uplift" with a fill level at roughly 70%. Mood: optimistic, data-driven, no hype.
+
+[paste global style anchors here]
+```
+
+---
+
+## Post 5: Roadmap + How to Contribute
+
+### Hero (1.91:1)
+
+```
+A horizontal timeline rendered as a stylized git commit graph stretching across the frame. Six distinct nodes are spaced along the timeline. The first three nodes (left side) are filled in solid accent color and labeled `v0.6`, `v1.0`, `v1.0.x` — these are "shipped." The next two nodes (center) are half-filled and labeled `v1.1`, `v1.2` — these are "in flight." The final node (right side) is a hollow outline labeled with a question mark — "your contribution." Three short branch lines diverge upward from the center, each ending in a small floating card labeled with one of the three community asks: `platform-parity`, `template-pack`, `experiment-data`. Mood: invitational, open, "the road continues."
+
+[paste global style anchors here]
+```
+
+### Supporting (1:1)
+
+```
+A clean illustration of three small contributor cards arranged vertically. Each card has a number (1, 2, 3) in the top-left corner in the accent color, and a short abstract icon representing the contribution type: card 1 has 9 small platform-logo silhouettes (left blank for legality — just abstract rounded squares), card 2 has stacked-paper templates icon with three different shapes, card 3 has a small histogram chart icon. The three cards are connected by a thin vertical line on the left edge, like a checklist. Background: dark slate, subtle dot grid. Mood: friendly, low-stakes, "pick one and start."
+
+[paste global style anchors here]
+```
+
+---
+
+## Recommended generators by post
+
+| Post | Best generator | Why |
+|------|---------------|-----|
+| 1 (teaser, mood-driven) | Midjourney v6 or Flux | Best at "stylized minimalist illustration" with mood |
+| 2 (infographic-style problem viz) | DALL-E 3 or Imagen | Best at clean infographic / chart compositions |
+| 3 (isometric workspace contract) | Midjourney v6 | Strong on isometric tech illustration |
+| 4 (photo-real workspace + chart screens) | Flux Pro or Imagen | Better photo-realism than MJ for screen content |
+| 5 (timeline + contributor cards) | DALL-E 3 | Cleanest at structured-layout illustrations |
+
+## Reusable prefix for any generator
+
+Drop this in front of any prompt above if the generator is producing too-busy or too-photographic output:
+
+```
+Editorial illustration in the style of a Stripe Press book cover or Increment magazine feature. Flat-ish 3D, soft shadows, controlled palette, generous negative space, no busy details. Subject should feel diagrammatic and intentional, not photorealistic.
+```
+
+## After generating
+
+Hand-edit in Figma or Canva to add:
+
+- The real `repo-context-hooks` logo (top-left or top-right corner)
+- The post title in a clean sans-serif (Inter, IBM Plex Sans, or Söhne)
+- Your handle / Substack URL in the bottom-right corner
+- One clear CTA strip at the bottom for LinkedIn variants (e.g. "github.com/narendranathe/repo-context-hooks")

--- a/marketing/posts/README.md
+++ b/marketing/posts/README.md
@@ -1,0 +1,40 @@
+# `repo-context-hooks` — Phased Launch Drafts
+
+Five phased posts, each with a Substack long-form draft and a LinkedIn short-form draft. Hashtags are at the bottom of each LinkedIn variant. Designed to ship in the optimal LinkedIn engagement window (Tue / Wed / Thu, 9-11 AM CT).
+
+## Posting schedule (CT)
+
+| # | Slot | Theme | File |
+|---|------|-------|------|
+| 1 | **Fri 2026-05-15** or **Mon 2026-05-18**, 9-10 AM | Teaser / origin story — "why I built this" | [01-teaser.md](01-teaser.md) |
+| 2 | **Tue 2026-05-19**, 9-10 AM | The problem — context loss after compaction | [02-problem.md](02-problem.md) |
+| 3 | **Thu 2026-05-21**, 9-10 AM | The solution — `repo-context-hooks` + 10 USPs | [03-solution-usps.md](03-solution-usps.md) |
+| 4 | **Tue 2026-05-26**, 9-10 AM | Use cases + measurable impact (`measure experiment` deltas) | [04-metrics-use-cases.md](04-metrics-use-cases.md) |
+| 5 | **Thu 2026-05-28**, 9-10 AM | Roadmap, how to contribute, ask for feedback | [05-roadmap-contribute.md](05-roadmap-contribute.md) |
+
+## Cross-channel rules
+
+- **Substack**: long-form, narrative voice, one technical artifact per post (a chart, a diff, a CLI transcript), clear CTA at the end.
+- **LinkedIn**: 1300-1700 char hook, 5-7 short paras, hashtags as a footer, end with a question to drive comments.
+- **No em dashes / en dashes** — hyphens only.
+- **Concrete over abstract** — every claim points at a CLI command, a file path, or a measurable number.
+
+## Canonical hashtags
+
+Mix-and-match — 5-7 per LinkedIn post.
+
+**Core (always use 3-4 of these):**
+`#ClaudeCode` `#AIAgents` `#DeveloperTools` `#OpenSource` `#AIEngineering`
+
+**Topic (rotate):**
+`#PromptEngineering` `#LLMOps` `#AgenticAI` `#PythonDev` `#DevTooling` `#GitOps` `#ContextEngineering`
+
+**Long-tail (broaden reach):**
+`#SoftwareEngineering` `#BuildInPublic` `#100DaysOfCode` `#StartupTools` `#TechStack`
+
+## Standing CTAs (use one per post)
+
+- Star the repo: https://github.com/narendranathe/repo-context-hooks
+- Try it: `pip install repo-context-hooks && repo-context-hooks install --platform claude`
+- Subscribe to the Substack for the next post in the series
+- Open a discussion: https://github.com/narendranathe/repo-context-hooks/discussions


### PR DESCRIPTION
## Summary

Adds `marketing/posts/` — five phased launch drafts (Substack long-form + LinkedIn short-form variants), an index README with posting schedule + hashtag inventory, and per-post image-generation prompts.

## Files

- `marketing/posts/README.md` — schedule, hashtag inventory, cross-channel rules
- `marketing/posts/01-teaser.md` — origin story (Fri 5/15 or Mon 5/18)
- `marketing/posts/02-problem.md` — why compaction loses 20-30% per event (Tue 5/19)
- `marketing/posts/03-solution-usps.md` — install + 10 USPs (Thu 5/21)
- `marketing/posts/04-metrics-use-cases.md` — real `measure experiment` deltas (Tue 5/26)
- `marketing/posts/05-roadmap-contribute.md` — roadmap + 3 contribution asks (Thu 5/28)
- `marketing/posts/IMAGE-PROMPTS.md` — hero + supporting image prompts for Midjourney / DALL-E 3 / Flux / Imagen

## Scope

Drafts only. Not part of the stability contract. Safe to iterate post-merge.

## Test plan

- [ ] CI passes (CHANGELOG entry present under Unreleased -> Added).
- [ ] Public-surface guard green (no code surface change).
- [ ] Docs build (strict) green (marketing/ is outside the mkdocs nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)