### PR TITLE
docs(monitoring): refresh snapshot to 2026-05-17 + harden brittle README test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - `README.md` and `specs/README.md` refreshed to reflect the v1.0.0 ship: install snippet, badge row, USP framing, and the closed PRD #68 + PRD #104 milestones. No code or behavior change.
+- `docs/monitoring/history.json` + `docs/monitoring/index.html` regenerated via `repo-context-hooks measure --snapshot-dir docs/monitoring`. Snapshot moves forward from `2026-04-29` to `2026-05-17`: observed events 108 → 110, session-start events 107 → 109, active days 3 → 4, latest_seen advances to today. Score, baseline, uplift, and lifecycle coverage unchanged (90/20/+70/25%). README telemetry table updated to match. Also exercises `pages.yml` end-to-end under the newly-bumped `actions/checkout@v6` (PR #83) — this is the first docs-path push since that bump merged.
+
+### Tests
+- `tests/test_monitoring_surface.py::test_readme_embeds_monitoring_brand_assets` now derives the `observed_events`, `score`, and `uplift` assertions from `docs/monitoring/history.json` instead of hard-coding `108`/`90`/`70` literals. Mirrors the snapshot-aware sibling test `test_readme_uses_latest_local_telemetry_proof_values`. Without this, every `measure --snapshot-dir docs/monitoring` refresh would red-X CI until someone bumped a magic number in the test.
 
 ### Deprecated
 <!-- none -->

--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ The numbers below come from this repo's own local telemetry log (`docs/monitorin
 | Contract score | **90 / 100** |
 | Baseline without hooks | 20 / 100 |
 | Continuity uplift | **+70 points** |
-| Hook events recorded | 108 |
-| Active days | 3 |
+| Hook events recorded | 110 |
+| Active days | 4 |
 | Lifecycle coverage | 25% |
-| Session-start events | 107 |
+| Session-start events | 109 |
 | Decision events | 1 |
 | Checkpoint/reload/session-end events | 0 |
 

--- a/docs/monitoring/history.json
+++ b/docs/monitoring/history.json
@@ -2,27 +2,27 @@
   "baseline": 20,
   "event_counts": {
     "decision": 1,
-    "session-start": 107
+    "session-start": 109
   },
   "first_seen": "2026-04-26T19:57:31.854624+00:00",
   "forecast": {
     "confidence": "medium",
-    "daily_rate": 36.0,
+    "daily_rate": 27.5,
     "projected_active_days": 30,
-    "projected_events": 1080,
+    "projected_events": 825,
     "week_series": [
-      252,
-      252,
-      252,
-      252,
-      72
+      192,
+      192,
+      192,
+      192,
+      55
     ]
   },
-  "latest_seen": "2026-04-28T04:39:16.846104+00:00",
-  "observed_events": 108,
+  "latest_seen": "2026-05-17T02:25:15.546097+00:00",
+  "observed_events": 110,
   "repo": "repo-context-hooks",
   "score": 90,
-  "snapshot_at": "2026-04-29T14:24:07Z",
+  "snapshot_at": "2026-05-17T03:06:53Z",
   "time_series": [
     {
       "date": "2026-04-26",
@@ -38,20 +38,25 @@
       "date": "2026-04-28",
       "events": 15,
       "score": 90
+    },
+    {
+      "date": "2026-05-17",
+      "events": 2,
+      "score": 90
     }
   ],
   "uplift": 70,
   "usability": {
-    "active_days": 3,
+    "active_days": 4,
     "avg_session_duration_minutes": null,
     "checkpoint_events": 0,
     "cold_start_time_saved_minutes": 0,
     "lifecycle_coverage": 25,
     "max_session_duration_minutes": null,
-    "readiness_minutes_since_last_event": 2025,
+    "readiness_minutes_since_last_event": 42,
     "reload_events": 0,
-    "resume_events": 107,
-    "score_week1_uplift": null,
+    "resume_events": 109,
+    "score_week1_uplift": 0,
     "session_end_events": 0
   }
 }

--- a/docs/monitoring/index.html
+++ b/docs/monitoring/index.html
@@ -168,7 +168,7 @@
         <div class="metric"><span>Contract score</span><strong>90</strong></div>
         <div class="metric"><span>Baseline (no hooks)</span><strong>20</strong></div>
         <div class="metric"><span>Continuity uplift</span><strong>+70</strong></div>
-        <div class="metric"><span>Hook events total</span><strong>108</strong></div>
+        <div class="metric"><span>Hook events total</span><strong>110</strong></div>
       </div>
 
       <!-- Activity + event mix -->
@@ -178,11 +178,12 @@
           <div class="bar-row"><span>2026-04-26</span><div class="bar-track"><div class="bar-fill" style="width:16%"></div></div><strong>13</strong></div>
 <div class="bar-row"><span>2026-04-27</span><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><strong>80</strong></div>
 <div class="bar-row"><span>2026-04-28</span><div class="bar-track"><div class="bar-fill" style="width:19%"></div></div><strong>15</strong></div>
+<div class="bar-row"><span>2026-05-17</span><div class="bar-track"><div class="bar-fill" style="width:4%"></div></div><strong>2</strong></div>
         </section>
         <section class="panel">
           <h2>Event mix</h2>
           <div class="events"><div><span>decision</span><strong>1</strong></div>
-<div><span>session-start</span><strong>107</strong></div></div>
+<div><span>session-start</span><strong>109</strong></div></div>
         </section>
       </div>
 
@@ -197,7 +198,7 @@
                 25% of the 4-event lifecycle is instrumented.
                 session-start is active. session-end, pre-compact, and post-compact are not yet observed in this snapshot.
               </p>
-              <div class="lc-grid"><div class="lc-pill lc-active"><span>session-start</span><strong>107</strong></div><div class="lc-pill lc-empty"><span>pre-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>post-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>session-end</span><strong>0</strong></div></div>
+              <div class="lc-grid"><div class="lc-pill lc-active"><span>session-start</span><strong>109</strong></div><div class="lc-pill lc-empty"><span>pre-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>post-compact</span><strong>0</strong></div><div class="lc-pill lc-empty"><span>session-end</span><strong>0</strong></div></div>
             </div>
           </div>
         </section>
@@ -206,6 +207,7 @@
           <div class="score-point"><span>2026-04-26</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
 <div class="score-point"><span>2026-04-27</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
 <div class="score-point"><span>2026-04-28</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
+<div class="score-point"><span>2026-05-17</span><strong>90</strong><div class="bar-track"><div class="bar-fill moss" style="width:90%"></div></div></div>
         </section>
       </div>
 
@@ -214,7 +216,7 @@
         <section class="panel">
           <h2>Recent hook evidence</h2>
           <ol><li><span>session-start</span><strong>score 90</strong><em>repo_specs_memory</em></li>
-<li><span>decision</span><strong>score 90</strong><em>repo_specs_memory</em></li>
+<li><span>session-start</span><strong>score 90</strong><em>repo_specs_memory</em></li>
 <li><span>session-start</span><strong>score 90</strong><em>repo_specs_memory</em></li>
 <li><span>session-start</span><strong>score 90</strong><em>repo_specs_memory</em></li>
 <li><span>session-start</span><strong>score 90</strong><em>repo_specs_memory</em></li>
@@ -225,8 +227,8 @@
         <section class="panel">
           <h2>Usability metrics</h2>
           <div class="usability">
-            <div><span>Active days</span><strong>3</strong></div>
-            <div><span>Session-start events</span><strong>107</strong></div>
+            <div><span>Active days</span><strong>4</strong></div>
+            <div><span>Session-start events</span><strong>109</strong></div>
             <div><span>Checkpoints</span><strong>0</strong></div>
             <div><span>Reloads</span><strong>0</strong></div>
             <div><span>Session ends</span><strong>0</strong></div>
@@ -241,11 +243,11 @@
         <section class="panel">
           <h2>30-day projection <small style="font-size:14px;font-weight:400;opacity:.6">from current local sample; confidence: medium</small></h2>
           <div class="metrics4">
-            <div class="metric"><span>Daily rate</span><strong>36.0</strong></div>
-            <div class="metric"><span>Projected events</span><strong>1,080</strong></div>
+            <div class="metric"><span>Daily rate</span><strong>27.5</strong></div>
+            <div class="metric"><span>Projected events</span><strong>825</strong></div>
             <div class="metric"><span>Active days (30d)</span><strong>30</strong></div>
           </div>
-          <div class="fc-grid"><div class="fc-week"><span>Week 1</span><strong>252</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 2</span><strong>252</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 3</span><strong>252</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 4</span><strong>252</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 5</span><strong>72</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div></div>
+          <div class="fc-grid"><div class="fc-week"><span>Week 1</span><strong>192</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 2</span><strong>192</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 3</span><strong>192</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 4</span><strong>192</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div><div class="fc-week"><span>Week 5</span><strong>55</strong><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div></div></div>
         </section>
         <section class="panel">
           <h2>Platform surface</h2>

--- a/tests/test_monitoring_surface.py
+++ b/tests/test_monitoring_surface.py
@@ -72,6 +72,12 @@ def test_readme_hero_visual_exists_and_carries_core_story() -> None:
 
 def test_readme_embeds_monitoring_brand_assets() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    # Pull live values from the same history.json the README is sourced from,
+    # so a `measure --snapshot-dir docs/monitoring` refresh does not require
+    # touching this test. The snapshot-aware sibling test
+    # (`test_readme_uses_latest_local_telemetry_proof_values`) follows the
+    # same pattern.
+    history = json.loads((ROOT / "docs" / "monitoring" / "history.json").read_text(encoding="utf-8"))
 
     assert "assets/brand/repo-context-hooks-logo.png" in readme
     assert "assets/diagrams/context-continuity-engine.svg" in readme
@@ -81,9 +87,9 @@ def test_readme_embeds_monitoring_brand_assets() -> None:
     assert "Telemetry Visibility" in readme
     assert "Observable Plot" in readme
     assert "Vega-Lite" in readme
-    assert "90 / 100" in readme
-    assert "+70 points" in readme
-    assert "108" in readme
+    assert f"{history['score']} / 100" in readme
+    assert f"+{history['uplift']} points" in readme
+    assert str(history["observed_events"]) in readme
     assert "Local operational telemetry" in readme
 
 


### PR DESCRIPTION
## Summary

- Regenerates `docs/monitoring/history.json` and `docs/monitoring/index.html` via `repo-context-hooks measure --snapshot-dir docs/monitoring`. Snapshot moves from `2026-04-29` to `2026-05-17`; the previous snapshot predated all of the late-April/mid-May session activity.
- Updates the README telemetry table to match (108→110 events, 107→109 session-start, 3→4 active days). Score, baseline, uplift, lifecycle coverage unchanged (90/20/+70/25%).
- Hardens `tests/test_monitoring_surface.py::test_readme_embeds_monitoring_brand_assets` to derive its assertions from `docs/monitoring/history.json` instead of hard-coding `108`/`90`/`70`. Mirrors the snapshot-aware sibling `test_readme_uses_latest_local_telemetry_proof_values`. Without this, every future snapshot refresh would red-X CI.

## Side effect (intentional)

This is the first push to a `docs/**` path since `actions/checkout` was bumped from v4 to v6 (PR #83). The post-merge `Deploy docs to GitHub Pages` run will therefore runtime-exercise:

- `actions/checkout@v6` credential handling (the v6 change moves persisted creds out of `.git/config`)
- `mike alias --push` + `mike set-default --push latest` from PR #130 under the new checkout
- mkdocs strict build under the post-#129 marketing-posts state

If any of those break, we'll see it on this PR's post-merge Deploy docs run rather than discovering it weeks from now on an unrelated push.

## Test plan

- [x] `repo-context-hooks measure --repo-root .` shows live values match the new snapshot (score 90, 110 events, 4 active days)
- [x] 24/24 README + monitoring contract tests pass locally
- [x] 618/618 full repo test suite passes locally
- [ ] CI green on this PR (against new snapshot)
- [ ] After merge: `Deploy docs to GitHub Pages` succeeds end-to-end under `actions/checkout@v6`
- [ ] After merge: `gh-pages/versions.json` still has `1.0.0 [latest]` (the bootstrap step from PR #130 should now hit branch 1 — "latest alias already present" — not re-bootstrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)